### PR TITLE
add support for Flight Cheapest Dates Search API

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,11 @@ $amadeus->getShopping()->getAvailability()->getFlightAvailabilities()->post($bod
 
 /* Airport Routes */
 // function get(array $params) :
-$amadeus->getAirport()->getDirectDestinations()->get([["departureAirportCode" => "MAD", "max" => 2]]);
+$amadeus->getAirport()->getDirectDestinations()->get(["departureAirportCode" => "MAD", "max" => 2]);
+
+/* Flight Cheapest Date Search */
+// function get(array $params) :
+$amadeus->getShopping()->getFlightDates()->get(["origin"=>"MAD", "destination"=>"LON"]);
 ```
 
 ## Development & Contributing

--- a/src/Shopping.php
+++ b/src/Shopping.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Amadeus;
 
 use Amadeus\Shopping\Availability;
+use Amadeus\Shopping\FlightDates;
 use Amadeus\Shopping\FlightOffers;
 use Amadeus\Shopping\HotelOffer;
 use Amadeus\Shopping\HotelOffers;
@@ -59,6 +60,14 @@ class Shopping
     private ?HotelOffers $hotelOffers;
 
     /**
+     * <p>
+     *   A namespaced client for the
+     *   <code>/v1/shopping/flight-dates</code> endpoints.
+     * </p>
+     */
+    private ?FlightDates $flightDates;
+
+    /**
      * @param Amadeus $amadeus
      */
     public function __construct(Amadeus $amadeus)
@@ -67,6 +76,7 @@ class Shopping
         $this->flightOffers = new FlightOffers($amadeus);
         $this->hotelOffer = new HotelOffer($amadeus);
         $this->hotelOffers = new HotelOffers($amadeus);
+        $this->flightDates = new FlightDates($amadeus);
     }
 
     /**
@@ -115,5 +125,17 @@ class Shopping
     public function getHotelOffers(): ?HotelOffers
     {
         return $this->hotelOffers;
+    }
+
+    /**
+     * <p>
+     *   Get a namespaced client for the
+     *   <code>/v1/shopping/flight-dates</code> endpoints.
+     * </p>
+     * @return FlightDates|null
+     */
+    public function getFlightDates(): ?FlightDates
+    {
+        return $this->flightDates;
     }
 }

--- a/src/resources/FlightDate.php
+++ b/src/resources/FlightDate.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Amadeus\Resources;
+
+use Amadeus\Shopping\FlightDates;
+
+/**
+ * A FlightDate object as returned by the Flight Cheapest Date Search API.
+ * @see FlightDates
+ * @see https://developers.amadeus.com/self-service/category/air/api-doc/flight-cheapest-date-search/api-reference
+ */
+class FlightDate extends Resource implements ResourceInterface
+{
+    private ?string $type = null;
+    private ?string $origin = null;
+    private ?string $destination = null;
+    private ?string $departureDate = null;
+    private ?string $returnDate = null;
+    private ?object $price = null;
+    private ?object $links = null;
+
+    /**
+     * @return string|null
+     */
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getOrigin(): ?string
+    {
+        return $this->origin;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getDestination(): ?string
+    {
+        return $this->destination;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getDepartureDate(): ?string
+    {
+        return $this->departureDate;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getReturnDate(): ?string
+    {
+        return $this->returnDate;
+    }
+
+    /**
+     * @return FlightPrice|null
+     */
+    public function getPrice(): ?object
+    {
+        return Resource::toResourceObject(
+            $this->price,
+            FlightPrice::class
+        );
+    }
+
+    /**
+     * @return FlightDateLinks|null
+     */
+    public function getLinks(): ?object
+    {
+        return Resource::toResourceObject(
+            $this->links,
+            FlightDateLinks::class
+        );
+    }
+
+    public function __set($name, $value): void
+    {
+        $this->$name = $value;
+    }
+
+    public function __toString(): string
+    {
+        return Resource::toString(get_object_vars($this));
+    }
+}

--- a/src/resources/FlightDateLinks.php
+++ b/src/resources/FlightDateLinks.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Amadeus\Resources;
+
+/**
+ * Sub-resource in FlightDate.
+ * @see FlightDate
+ */
+class FlightDateLinks implements ResourceInterface
+{
+    private ?string $flightDestinations = null;
+    private ?string $flightOffers = null;
+
+    /**
+     * @return string|null
+     */
+    public function getFlightDestinations(): ?string
+    {
+        return $this->flightDestinations;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getFlightOffers(): ?string
+    {
+        return $this->flightOffers;
+    }
+
+    public function __set($name, $value): void
+    {
+        $this->$name = $value;
+    }
+
+    public function __toString(): string
+    {
+        return Resource::toString(get_object_vars($this));
+    }
+}

--- a/src/shopping/FlightDates.php
+++ b/src/shopping/FlightDates.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Amadeus\Shopping;
+
+use Amadeus\Amadeus;
+use Amadeus\Exceptions\ResponseException;
+use Amadeus\Resources\FlightDate;
+use Amadeus\Resources\Resource;
+
+/**
+ * <p>
+ *   A namespaced client for the
+ *   <code>/v1/shopping/flight-dates</code> endpoints.
+ * </p>
+ *
+ * <p>
+ *   Access via the Amadeus client object.
+ * </p>
+ *
+ * <code>
+ *  $amadeus = Amadeus::builder("clientId", "secret")->build();
+ *  $amadeus->getShopping()->getFlightDates();
+ * </code>
+ */
+class FlightDates
+{
+    private Amadeus $amadeus;
+
+    /**
+     * @param Amadeus $amadeus
+     */
+    public function __construct(Amadeus $amadeus)
+    {
+        $this->amadeus = $amadeus;
+    }
+
+    /**
+     * ###Flight Cheapest Dates Search API
+     * <p>
+     *   Find the cheapest flight dates from an origin to a destination.
+     * </p>
+     *
+     * <code>
+     *  $amadeus->getShopping()->getFlightDates()->get(
+     *      array(
+     *              "origin" => "MAD",
+     *              "destination" => "LON"
+     *      )
+     * );
+     * </code>
+     *
+     * @see https://developers.amadeus.com/self-service/category/air/api-doc/flight-cheapest-date-search/api-reference
+     *
+     * @param array $params         the parameters to send to the API
+     * @return FlightDate[]         an API resource
+     * @throws ResponseException    when an exception occurs
+     */
+    public function get(array $params): array
+    {
+        $response = $this->amadeus->getClient()->getWithArrayParams(
+            "/v1/shopping/flight-dates",
+            $params
+        );
+
+        return Resource::fromArray($response, FlightDate::class);
+    }
+}

--- a/tests/AmadeusBuilderTest.php
+++ b/tests/AmadeusBuilderTest.php
@@ -31,6 +31,7 @@ use PHPUnit\Framework\TestCase;
  * @covers \Amadeus\Shopping
  * @covers \Amadeus\Shopping\Availability
  * @covers \Amadeus\Shopping\Availability\FlightAvailabilities
+ * @covers \Amadeus\Shopping\FlightDates
  * @covers \Amadeus\Shopping\FlightOffers
  * @covers \Amadeus\Shopping\FlightOffers\Pricing
  * @covers \Amadeus\Shopping\HotelOffer

--- a/tests/NamespaceTest.php
+++ b/tests/NamespaceTest.php
@@ -29,6 +29,7 @@ use PHPUnit\Framework\TestCase;
  * @covers \Amadeus\Shopping
  * @covers \Amadeus\Shopping\Availability
  * @covers \Amadeus\Shopping\Availability\FlightAvailabilities
+ * @covers \Amadeus\Shopping\FlightDates
  * @covers \Amadeus\Shopping\FlightOffers
  * @covers \Amadeus\Shopping\FlightOffers\Pricing
  * @covers \Amadeus\Shopping\HotelOffer
@@ -57,6 +58,7 @@ final class NamespaceTest extends TestCase
         $this->assertNotNull($amadeus->getShopping()->getFlightOffers()->getPricing());
         $this->assertNotNull($amadeus->getShopping()->getHotelOffer());
         $this->assertNotNull($amadeus->getShopping()->getHotelOffers());
+        $this->assertNotNull($amadeus->getShopping()->getFlightDates());
 
         // ReferenceData
         $this->assertNotNull($amadeus->getReferenceData());

--- a/tests/client/RequestTest.php
+++ b/tests/client/RequestTest.php
@@ -6,7 +6,6 @@ namespace Amadeus\Tests\Client;
 
 use Amadeus\Amadeus;
 use Amadeus\Client\Request;
-use Amadeus\Client\BasicHTTPClient;
 use Amadeus\Constants;
 use PHPUnit\Framework\TestCase;
 
@@ -35,6 +34,7 @@ use PHPUnit\Framework\TestCase;
  * @covers \Amadeus\Shopping
  * @covers \Amadeus\Shopping\Availability
  * @covers \Amadeus\Shopping\Availability\FlightAvailabilities
+ * @covers \Amadeus\Shopping\FlightDates
  * @covers \Amadeus\Shopping\FlightOffers
  * @covers \Amadeus\Shopping\FlightOffers\Pricing
  * @covers \Amadeus\Shopping\HotelOffer

--- a/tests/resources/__files/flight_dates_get_response_ok.json
+++ b/tests/resources/__files/flight_dates_get_response_ok.json
@@ -1,0 +1,32 @@
+{
+  "data": [
+    {
+      "type": "flight-date",
+      "origin": "MAD",
+      "destination": "MUC",
+      "departureDate": "2020-07-29",
+      "returnDate": "2020-07-30",
+      "price": {
+        "total": "98.53"
+      },
+      "links": {
+        "flightDestinations": "https://test.api.amadeus.com/v1/shopping/flight-destinations?origin=MAD&departureDate=2020-07-24,2021-01-19&oneWay=false&duration=1,15&nonStop=false&viewBy=DURATION",
+        "flightOffers": "https://test.api.amadeus.com/v2/shopping/flight-offers?originLocationCode=MAD&destinationLocationCode=MUC&departureDate=2020-07-29&returnDate=2020-07-30&adults=1&nonStop=false"
+      }
+    },
+    {
+      "type": "flight-date",
+      "origin": "MAD",
+      "destination": "MUC",
+      "departureDate": "2020-07-29",
+      "returnDate": "2020-07-31",
+      "price": {
+        "total": "98.53"
+      },
+      "links": {
+        "flightDestinations": "https://test.api.amadeus.com/v1/shopping/flight-destinations?origin=MAD&departureDate=2020-07-24,2021-01-19&oneWay=false&duration=1,15&nonStop=false&viewBy=DURATION",
+        "flightOffers": "https://test.api.amadeus.com/v2/shopping/flight-offers?originLocationCode=MAD&destinationLocationCode=MUC&departureDate=2020-07-29&returnDate=2020-07-31&adults=1&nonStop=false"
+      }
+    }
+  ]
+}

--- a/tests/shopping/FlightDatesTest.php
+++ b/tests/shopping/FlightDatesTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Amadeus\Tests\Shopping;
+
+use Amadeus\Amadeus;
+use Amadeus\Client\HTTPClient;
+use Amadeus\Client\Response;
+use Amadeus\Exceptions\ResponseException;
+use Amadeus\Resources\FlightDate;
+use Amadeus\Resources\FlightDateLinks;
+use Amadeus\Resources\FlightPrice;
+use Amadeus\Shopping\FlightDates;
+use Amadeus\Tests\PHPUnitUtil;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * This test covers the endpoint and its related returned resources.
+ * @covers \Amadeus\Shopping\FlightDates
+ *
+ * @covers \Amadeus\Resources\Resource
+ * @covers \Amadeus\Resources\FlightDate
+ * @covers \Amadeus\Resources\FlightPrice
+ * @covers \Amadeus\Resources\FlightDateLinks
+ *
+ * @covers \Amadeus\Client\Response
+ * @covers \Amadeus\Exceptions\ResponseException
+ * @covers \Amadeus\Exceptions\ClientException
+ *
+ * @see https://developers.amadeus.com/self-service/category/air/api-doc/flight-cheapest-date-search/api-reference
+ */
+final class FlightDatesTest extends TestCase
+{
+    private Amadeus $amadeus;
+    private HTTPClient $client;
+
+    /**
+     * @Before
+     */
+    public function setUp(): void
+    {
+        // Mock an Amadeus with HTTPClient
+        $this->amadeus = $this->createMock(Amadeus::class);
+        $this->client = $this->createMock(HTTPClient::class);
+        $this->amadeus->expects($this->any())
+            ->method("getClient")
+            ->willReturn($this->client);
+    }
+
+    /**
+     * @throws ResponseException
+     */
+    public function test_given_client_when_call_flight_dates_then_ok(): void
+    {
+        // Prepare Response
+        $fileContent = PHPUnitUtil::readFile(
+            PHPUnitUtil::RESOURCE_PATH_ROOT . "flight_dates_get_response_ok.json"
+        );
+        $data = json_decode($fileContent)->{'data'};
+        $response = $this->createMock(Response::class);
+        $response->expects($this->any())
+            ->method("getData")
+            ->willReturn($data);
+
+        // Given
+        $params = ["origin" => "MAD", "destination" => "MUC"];
+        /* @phpstan-ignore-next-line */
+        $this->client->expects($this->any())
+            ->method("getWithArrayParams")
+            ->with("/v1/shopping/flight-dates", $params)
+            ->willReturn($response);
+
+        // When
+        $flightDates = (new FlightDates($this->amadeus))->get($params);
+
+        // Then
+        $this->assertNotNull($flightDates);
+        $this->assertEquals(2, sizeof($flightDates));
+
+        // Resources
+        // FlightDate
+        $this->assertTrue($flightDates[0] instanceof FlightDate);
+        $this->assertEquals("flight-date", $flightDates[0]->getType());
+        $this->assertEquals("MAD", $flightDates[0]->getOrigin());
+        $this->assertEquals("MUC", $flightDates[0]->getDestination());
+        $this->assertEquals("2020-07-29", $flightDates[0]->getDepartureDate());
+        $this->assertEquals("2020-07-30", $flightDates[0]->getReturnDate());
+
+        // FlightPrice
+        $price = $flightDates[0]->getPrice();
+        $this->assertTrue($price instanceof FlightPrice);
+        $this->assertEquals("98.53", $price->getTotal());
+
+        // FlightDateLink
+        $links = $flightDates[0]->getLinks();
+        $this->assertTrue($links instanceof FlightDateLinks);
+        $this->assertEquals(
+            "https://test.api.amadeus.com/v1/shopping/flight-destinations?origin=MAD&departureDate=2020-07-24,2021-01-19&oneWay=false&duration=1,15&nonStop=false&viewBy=DURATION",
+            $links->getFlightDestinations()
+        );
+        $this->assertEquals(
+            "https://test.api.amadeus.com/v2/shopping/flight-offers?originLocationCode=MAD&destinationLocationCode=MUC&departureDate=2020-07-29&returnDate=2020-07-30&adults=1&nonStop=false",
+            $links->getFlightOffers()
+        );
+
+        // __toString()
+        $this->assertEquals(
+            PHPUnitUtil::toString($data[0]),
+            $flightDates[0]->__toString()
+        );
+        $this->assertEquals(
+            PHPUnitUtil::toString($data[0]->{'price'}),
+            $price->__toString()
+        );
+        $this->assertEquals(
+            PHPUnitUtil::toString($data[0]->{'links'}),
+            $links->__toString()
+        );
+    }
+}


### PR DESCRIPTION
Fixes #26 

- [x] ResouceModel - FlightDate
- [x] Namespced Client and API support- ```$amadeus->getShopping()->getFlightDates()->get($params)```
- [x] Namespace Test 
- [x] Endpoint Test
