### PR TITLE
add support for Airline Code Lookup API

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,10 @@ $amadeus->getAirport()->getDirectDestinations()->get(["departureAirportCode" => 
 /* Flight Cheapest Date Search */
 // function get(array $params) :
 $amadeus->getShopping()->getFlightDates()->get(["origin"=>"MAD", "destination"=>"LON"]);
+
+/* Airline Code Lookup */
+// function get(array $params) :
+$amadeus->getReferenceData()->getAirlines()->get(["airlineCodes"=>"BA"]);
 ```
 
 ## Development & Contributing

--- a/src/ReferenceData.php
+++ b/src/ReferenceData.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Amadeus;
 
+use Amadeus\ReferenceData\Airlines;
 use Amadeus\ReferenceData\Locations;
 
 /**
@@ -23,7 +24,21 @@ use Amadeus\ReferenceData\Locations;
  */
 class ReferenceData
 {
+    /**
+     * <p>
+     *   A namespaced client for the
+     *   <code>/v1/reference-data/locations</code> endpoints.
+     * </p>
+     */
     private ?Locations $locations;
+
+    /**
+     * <p>
+     *   A namespaced client for the
+     *   <code>/v1/reference-data/airlines</code> endpoints.
+     * </p>
+     */
+    private ?Airlines $airlines;
 
     /**
      * @param Amadeus $amadeus
@@ -31,13 +46,30 @@ class ReferenceData
     public function __construct(Amadeus $amadeus)
     {
         $this->locations = new Locations($amadeus);
+        $this->airlines = new Airlines($amadeus);
     }
 
     /**
+     * <p>
+     *   Get a namespaced client for the
+     *   <code>/v1/reference-data/locations</code> endpoints.
+     * </p>
      * @return Locations|null
      */
     public function getLocations(): ?Locations
     {
         return $this->locations;
+    }
+
+    /**
+     * <p>
+     *   Get a namespaced client for the
+     *   <code>/v1/reference-data/airlines</code> endpoints.
+     * </p>
+     * @return Airlines|null
+     */
+    public function getAirlines(): ?Airlines
+    {
+        return $this->airlines;
     }
 }

--- a/src/referenceData/Airlines.php
+++ b/src/referenceData/Airlines.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Amadeus\ReferenceData;
+
+use Amadeus\Amadeus;
+use Amadeus\Exceptions\ResponseException;
+use Amadeus\Resources\Airline;
+use Amadeus\Resources\Resource;
+
+/**
+ * <p>
+ *   A namespaced client for the
+ *   <code>/v1/reference-data/airlines</code> endpoints.
+ * </p>
+ *
+ * <p>
+ *   Access via the Amadeus client object.
+ * </p>
+ *
+ * <code>
+ *  $amadeus = Amadeus::builder("clientId", "secret")->build();
+ *  $amadeus->getReferenceData()->getAirlines();
+ * </code>
+ */
+class Airlines
+{
+    private Amadeus $amadeus;
+
+    /**
+     * @param Amadeus $amadeus
+     */
+    public function __construct(Amadeus $amadeus)
+    {
+        $this->amadeus = $amadeus;
+    }
+
+    /**
+     * ###Airline Code Lookup API
+     * <p>
+     *    Returns a list of Airlines information.
+     * </p>
+     *
+     * <code>
+     *  $amadeus->getReferenceData()->getAirlines()->get(
+     *      ["airlineCodes" => "BA"]
+     *  );
+     * </code>
+     *
+     * @see https://developers.amadeus.com/self-service/category/air/api-doc/airline-code-lookup/api-reference
+     *
+     * @param array $params
+     * @return Airline[]           an API resource
+     * @throws ResponseException when an exception occurs
+     */
+    public function get(array $params): array
+    {
+        $response = $this->amadeus->getClient()->getWithArrayParams(
+            '/v1/reference-data/airlines',
+            $params
+        );
+
+        return Resource::fromArray($response, Airline::class);
+    }
+}

--- a/src/resources/Airline.php
+++ b/src/resources/Airline.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Amadeus\Resources;
+
+use Amadeus\ReferenceData\Airlines;
+
+/**
+ * An Airline object as returned by the Airline Code Lookup API.
+ * @see Airlines
+ * @see https://developers.amadeus.com/self-service/category/air/api-doc/airline-code-lookup/api-reference
+ */
+class Airline extends Resource implements ResourceInterface
+{
+    private ?string $type = null;
+    private ?string $iataCode = null;
+    private ?string $icaoCode = null;
+    private ?string $businessName = null;
+    private ?string $commonName = null;
+
+    /**
+     * @return string|null
+     */
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getIataCode(): ?string
+    {
+        return $this->iataCode;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getIcaoCode(): ?string
+    {
+        return $this->icaoCode;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getBusinessName(): ?string
+    {
+        return $this->businessName;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getCommonName(): ?string
+    {
+        return $this->commonName;
+    }
+
+    public function __set($name, $value): void
+    {
+        $this->$name = $value;
+    }
+
+    public function __toString(): string
+    {
+        return Resource::toString(get_object_vars($this));
+    }
+}

--- a/tests/NamespaceTest.php
+++ b/tests/NamespaceTest.php
@@ -20,6 +20,7 @@ use PHPUnit\Framework\TestCase;
  * @covers \Amadeus\Booking\FlightOrders
  * @covers \Amadeus\Booking\HotelBookings
  * @covers \Amadeus\ReferenceData
+ * @covers \Amadeus\ReferenceData\Airlines
  * @covers \Amadeus\ReferenceData\Locations
  * @covers \Amadeus\ReferenceData\Locations\Hotel
  * @covers \Amadeus\ReferenceData\Locations\Hotels
@@ -68,5 +69,6 @@ final class NamespaceTest extends TestCase
         $this->assertNotNull($amadeus->getReferenceData()->getLocations()->getHotels()->getByCity());
         $this->assertNotNull($amadeus->getReferenceData()->getLocations()->getHotels()->getByGeocode());
         $this->assertNotNull($amadeus->getReferenceData()->getLocations()->getHotels()->getByHotels());
+        $this->assertNotNull($amadeus->getReferenceData()->getAirlines());
     }
 }

--- a/tests/referenceData/AirlinesTest.php
+++ b/tests/referenceData/AirlinesTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Amadeus\Tests\ReferenceData;
+
+use Amadeus\Amadeus;
+use Amadeus\Client\HTTPClient;
+use Amadeus\Client\Response;
+use Amadeus\Exceptions\ResponseException;
+use Amadeus\ReferenceData\Airlines;
+use Amadeus\Resources\Airline;
+use Amadeus\Tests\PHPUnitUtil;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * This test covers the endpoint and its related returned resources.
+ * @covers \Amadeus\ReferenceData\Airlines
+ *
+ * @covers \Amadeus\Resources\Resource
+ * @covers \Amadeus\Resources\Airline
+ *
+ * @see https://developers.amadeus.com/self-service/category/air/api-doc/airline-code-lookup/api-reference
+ */
+final class AirlinesTest extends TestCase
+{
+    private Amadeus $amadeus;
+    private HTTPClient $client;
+
+    /**
+     * @Before
+     */
+    public function setUp(): void
+    {
+        // Mock an Amadeus with HTTPClient
+        $this->amadeus = $this->createMock(Amadeus::class);
+        $this->client = $this->createMock(HTTPClient::class);
+        $this->amadeus->expects($this->any())
+            ->method("getClient")
+            ->willReturn($this->client);
+    }
+
+    /**
+     * @throws ResponseException
+     */
+    public function test_given_client_when_call_airlines_then_ok(): void
+    {
+        // Prepare Response
+        $fileContent = PHPUnitUtil::readFile(
+            PHPUnitUtil::RESOURCE_PATH_ROOT . "airlines_get_response_ok.json"
+        );
+        $data = json_decode($fileContent)->{'data'};
+        $response = $this->createMock(Response::class);
+        $response->expects($this->any())
+            ->method("getData")
+            ->willReturn($data);
+
+        // Given
+        $params = ["iataCodes" => "BA"];
+        /* @phpstan-ignore-next-line */
+        $this->client->expects($this->any())
+            ->method("getWithArrayParams")
+            ->with("/v1/reference-data/airlines", $params)
+            ->willReturn($response);
+
+        // When
+        $airlines = (new Airlines($this->amadeus))->get($params);
+
+        // Then
+        $this->assertNotNull($airlines);
+        $this->assertEquals(1, sizeof($airlines));
+
+        // Resources
+        // Destination
+        $this->assertTrue($airlines[0] instanceof Airline);
+        $this->assertEquals("airline", $airlines[0]->getType());
+        $this->assertEquals("BA", $airlines[0]->getIataCode());
+        $this->assertEquals("BAW", $airlines[0]->getIcaoCode());
+        $this->assertEquals("BRITISH AIRWAYS", $airlines[0]->getBusinessName());
+        $this->assertEquals("BRITISH A/W", $airlines[0]->getCommonName());
+
+        // __toString()
+        $this->assertEquals(
+            PHPUnitUtil::toString($data[0]),
+            $airlines[0]->__toString()
+        );
+    }
+}

--- a/tests/referenceData/AirlinesTest.php
+++ b/tests/referenceData/AirlinesTest.php
@@ -71,7 +71,7 @@ final class AirlinesTest extends TestCase
         $this->assertEquals(1, sizeof($airlines));
 
         // Resources
-        // Destination
+        // Airline
         $this->assertTrue($airlines[0] instanceof Airline);
         $this->assertEquals("airline", $airlines[0]->getType());
         $this->assertEquals("BA", $airlines[0]->getIataCode());

--- a/tests/resources/__files/airlines_get_response_ok.json
+++ b/tests/resources/__files/airlines_get_response_ok.json
@@ -1,0 +1,17 @@
+{
+  "meta": {
+    "count": 1,
+    "links": {
+      "self": "https://test.api.amadeus.com/v1/reference-data/airlines?airlineCodes=BA"
+    }
+  },
+  "data": [
+    {
+      "type": "airline",
+      "iataCode": "BA",
+      "icaoCode": "BAW",
+      "businessName": "BRITISH AIRWAYS",
+      "commonName": "BRITISH A/W"
+    }
+  ]
+}

--- a/tests/shopping/FlightDatesTest.php
+++ b/tests/shopping/FlightDatesTest.php
@@ -24,10 +24,6 @@ use PHPUnit\Framework\TestCase;
  * @covers \Amadeus\Resources\FlightPrice
  * @covers \Amadeus\Resources\FlightDateLinks
  *
- * @covers \Amadeus\Client\Response
- * @covers \Amadeus\Exceptions\ResponseException
- * @covers \Amadeus\Exceptions\ClientException
- *
  * @see https://developers.amadeus.com/self-service/category/air/api-doc/flight-cheapest-date-search/api-reference
  */
 final class FlightDatesTest extends TestCase


### PR DESCRIPTION
Fixes #31 

- [x] Resource Model - ```Airline.php```
- [x] Namespced Client and API support- ```$amadeus->getReferenceData()->getAirlines()->get($params)```
- [x] Namespace Test - ```NamespaceTest.php```
- [x] Endpoint and Resource Test - ```AirlinesTest.php```

Besides, some deletion on ```FlightDatesTest.php``` because of some useless annotations. 