### PR TITLE
add support for On-Demand Flight Status API

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,10 @@ $amadeus->getAirport()->getDirectDestinations()->get(["departureAirportCode" => 
 /* Flight Cheapest Date Search */
 // function get(array $params) :
 $amadeus->getShopping()->getFlightDates()->get(["origin"=>"MAD", "destination"=>"LON"]);
+
+/* On-Demand Flight Status */
+// function get(array $params) :
+$amadeus->getSchedule()->getFlights()->get(["carrierCode"=>"IB", "flightNumber"=>532, "scheduledDepartureDate"=>"2022-09-23"]);
 ```
 
 ## Development & Contributing

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
       "Amadeus\\ReferenceData\\Locations\\": "src/referenceData/locations",
       "Amadeus\\ReferenceData\\Locations\\Hotels\\": "src/referenceData/locations/hotels",
       "Amadeus\\Resources\\": "src/resources",
+      "Amadeus\\Schedule\\": "src/schedule",
       "Amadeus\\Shopping\\": "src/shopping",
       "Amadeus\\Shopping\\Availability\\": "src/shopping/availability",
       "Amadeus\\Shopping\\FlightOffers\\": "src/shopping/flightOffers"
@@ -45,6 +46,7 @@
       "Amadeus\\Tests\\ReferenceData\\Locations\\": "tests/referenceData/locations",
       "Amadeus\\Tests\\ReferenceData\\Locations\\Hotels\\": "tests/referenceData/locations/hotels",
       "Amadeus\\Tests\\Resources\\": "tests/resources",
+      "Amadeus\\Tests\\Schedule\\": "tests/schedule",
       "Amadeus\\Tests\\Shopping\\": "tests/shopping",
       "Amadeus\\Tests\\Shopping\\Availability\\": "tests/shopping/availability",
       "Amadeus\\Tests\\Shopping\\FlightOffers\\": "tests/shopping/flightOffers"

--- a/src/Amadeus.php
+++ b/src/Amadeus.php
@@ -57,6 +57,13 @@ class Amadeus
     private Booking $booking;
 
     /**
+     * <p>
+     * A namespaced client for the <code>/schedule</code> endpoints.
+     * </p>
+     */
+    private Schedule $schedule;
+
+    /**
      * @param Configuration $configuration
      */
     public function __construct(
@@ -70,6 +77,7 @@ class Amadeus
         $this->shopping = new Shopping($this);
         $this->referenceData = new ReferenceData($this);
         $this->booking = new Booking($this);
+        $this->schedule = new Schedule($this);
     }
 
     /**
@@ -152,5 +160,16 @@ class Amadeus
     public function getBooking(): Booking
     {
         return $this->booking;
+    }
+
+    /**
+     * <p>
+     * Get a namespaced client for the <code>/schedule</code> endpoints.
+     * </p>
+     * @return Schedule
+     */
+    public function getSchedule(): Schedule
+    {
+        return $this->schedule;
     }
 }

--- a/src/Schedule.php
+++ b/src/Schedule.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Amadeus;
+
+use Amadeus\Schedule\Flights;
+
+/**
+ * <p>
+ *   A namespaced client for the
+ *   <code>/schedule</code> endpoints.
+ * </p>
+ *
+ * <p>
+ *   Access via the Amadeus client object.
+ * </p>
+ *
+ * <code>
+ *  $amadeus = Amadeus::builder("clientId", "secret")->build();
+ *  $amadeus->getSchedule();
+ * </code>
+ */
+class Schedule
+{
+    /**
+     * <p>
+     *   A namespaced client for the
+     *   <code>/v2/schedule/flights</code> endpoints.
+     * </p>
+     */
+    private ?Flights $flights;
+
+    /**
+     * @param Amadeus $amadeus
+     */
+    public function __construct(Amadeus $amadeus)
+    {
+        $this->flights = new Flights($amadeus);
+    }
+
+    /**
+     * <p>
+     *   Get a namespaced client for the
+     *   <code>/v2/schedule/flights</code> endpoints.
+     * </p>
+     * @return Flights|null
+     */
+    public function getFlights(): ?Flights
+    {
+        return $this->flights;
+    }
+}

--- a/src/resources/DatedFlight.php
+++ b/src/resources/DatedFlight.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Amadeus\Resources;
+
+/**
+ * A DatedFlight object as returned by the On-Demand Flight Status API.
+ * @see
+ * @see https://developers.amadeus.com/self-service/category/air/api-doc/on-demand-flight-status/api-reference
+ */
+class DatedFlight extends Resource implements ResourceInterface
+{
+    private ?string $type = null;
+    private ?string $scheduledDepartureDate = null;
+    private ?object $flightDesignator= null;
+    private ?array $flightPoints = null;
+    private ?array $segments = null;
+    private ?array $legs = null;
+
+    /**
+     * @return string|null
+     */
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getScheduledDepartureDate(): ?string
+    {
+        return $this->scheduledDepartureDate;
+    }
+
+    /**
+     * @return FlightDesignator|null
+     */
+    public function getFlightDesignator(): ?object
+    {
+        return Resource::toResourceObject(
+            $this->flightDesignator,
+            FlightDesignator::class
+        );
+    }
+
+    /**
+     * @return FlightPoint[]|null
+     */
+    public function getFlightPoints(): ?array
+    {
+        return Resource::toResourceArray(
+            $this->flightPoints,
+            FlightPoint::class
+        );
+    }
+
+    /**
+     * @return DatedFlightSegment[]|null
+     */
+    public function getSegments(): ?array
+    {
+        return Resource::toResourceArray(
+            $this->segments,
+            DatedFlightSegment::class
+        );
+    }
+
+    /**
+     * @return DatedFlightLeg[]|null
+     */
+    public function getLegs(): ?array
+    {
+        return Resource::toResourceArray(
+            $this->legs,
+            DatedFlightLeg::class
+        );
+    }
+
+    public function __set($name, $value): void
+    {
+        $this->$name = $value;
+    }
+
+    public function __toString(): string
+    {
+        return Resource::toString(get_object_vars($this));
+    }
+}

--- a/src/resources/DatedFlightLeg.php
+++ b/src/resources/DatedFlightLeg.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Amadeus\Resources;
+
+/**
+ * Sub-resource in DatedFlight
+ * @see DatedFlight
+ */
+class DatedFlightLeg implements ResourceInterface
+{
+    private ?string $boardPointIataCode = null;
+    private ?string $offPointIataCode = null;
+    private ?object $aircraftEquipment = null;
+    private ?string $scheduledLegDuration = null;
+
+    /**
+     * @return string|null
+     */
+    public function getBoardPointIataCode(): ?string
+    {
+        return $this->boardPointIataCode;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getOffPointIataCode(): ?string
+    {
+        return $this->offPointIataCode;
+    }
+
+    /**
+     * @return AircraftEquipment|null
+     */
+    public function getAircraftEquipment(): ?object
+    {
+        return Resource::toResourceObject(
+            $this->aircraftEquipment,
+            AircraftEquipment::class
+        );
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getScheduledLegDuration(): ?string
+    {
+        return $this->scheduledLegDuration;
+    }
+
+    public function __set($name, $value): void
+    {
+        $this->$name = $value;
+    }
+
+    public function __toString(): string
+    {
+        return Resource::toString(get_object_vars($this));
+    }
+}

--- a/src/resources/DatedFlightSegment.php
+++ b/src/resources/DatedFlightSegment.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Amadeus\Resources;
+
+/**
+ * Sub-resource in DatedFlight
+ * @see DatedFlight
+ */
+class DatedFlightSegment implements ResourceInterface
+{
+    private ?string $boardPointIataCode = null;
+    private ?string $offPointIataCode = null;
+    private ?string $scheduledSegmentDuration = null;
+    private ?object $partnership = null;
+
+    /**
+     * @return string|null
+     */
+    public function getBoardPointIataCode(): ?string
+    {
+        return $this->boardPointIataCode;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getOffPointIataCode(): ?string
+    {
+        return $this->offPointIataCode;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getScheduledSegmentDuration(): ?string
+    {
+        return $this->scheduledSegmentDuration;
+    }
+
+    /**
+     * @return DatedFlightSegmentPartnership|null
+     */
+    public function getPartnership(): ?object
+    {
+        return Resource::toResourceObject(
+            $this->partnership,
+            DatedFlightSegmentPartnership::class
+        );
+    }
+
+    public function __set($name, $value): void
+    {
+        $this->$name = $value;
+    }
+
+    public function __toString(): string
+    {
+        return Resource::toString(get_object_vars($this));
+    }
+}

--- a/src/resources/DatedFlightSegmentPartnership.php
+++ b/src/resources/DatedFlightSegmentPartnership.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Amadeus\Resources;
+
+/**
+ * Sub-resource in Segment
+ * @see DatedFlightSegment
+ */
+class DatedFlightSegmentPartnership implements ResourceInterface
+{
+    private ?object $operatingFlight = null;
+
+    /**
+     * @return FlightDesignator|null
+     */
+    public function getOperatingFlight(): ?object
+    {
+        return Resource::toResourceObject(
+            $this->operatingFlight,
+            FlightDesignator::class
+        );
+    }
+
+    public function __set($name, $value): void
+    {
+        $this->$name = $value;
+    }
+
+    public function __toString(): string
+    {
+        return Resource::toString(get_object_vars($this));
+    }
+}

--- a/src/resources/FlightDesignator.php
+++ b/src/resources/FlightDesignator.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Amadeus\Resources;
+
+/**
+ * Sub-resource in DatedFlight, Partnership
+ * @see DatedFlight, DatedFlightSegmentPartnership
+ */
+class FlightDesignator implements ResourceInterface
+{
+    private ?string $carrierCode = null;
+    private ?int $flightNumber = null;
+    private ?string $operationalSuffix = null;
+
+    /**
+     * @return string|null
+     */
+    public function getCarrierCode(): ?string
+    {
+        return $this->carrierCode;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getFlightNumber(): ?int
+    {
+        return $this->flightNumber;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getOperationalSuffix(): ?string
+    {
+        return $this->operationalSuffix;
+    }
+
+    public function __set($name, $value): void
+    {
+        $this->$name = $value;
+    }
+
+    public function __toString(): string
+    {
+        return Resource::toString(get_object_vars($this));
+    }
+}

--- a/src/resources/FlightPoint.php
+++ b/src/resources/FlightPoint.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Amadeus\Resources;
+
+/**
+ * Sub-resource in DatedFlight
+ * @see DatedFlight
+ */
+class FlightPoint implements ResourceInterface
+{
+    private ?string $iataCode = null;
+    private ?object $departure = null;
+    private ?object $arrival = null;
+
+    /**
+     * @return string|null
+     */
+    public function getIataCode(): ?string
+    {
+        return $this->iataCode;
+    }
+
+    /**
+     * @return FlightPointDeparture|null
+     */
+    public function getDeparture(): ?object
+    {
+        return Resource::toResourceObject(
+            $this->departure,
+            FlightPointDeparture::class
+        );
+    }
+
+    /**
+     * @return FlightPointArrival|null
+     */
+    public function getArrival(): ?object
+    {
+        return Resource::toResourceObject(
+            $this->arrival,
+            FlightPointArrival::class
+        );
+    }
+
+    public function __set($name, $value): void
+    {
+        $this->$name = $value;
+    }
+
+    public function __toString(): string
+    {
+        return Resource::toString(get_object_vars($this));
+    }
+}

--- a/src/resources/FlightPointArrival.php
+++ b/src/resources/FlightPointArrival.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Amadeus\Resources;
+
+/**
+ * Sub-resource in DatedFlight
+ * @see DatedFlight
+ */
+class FlightPointArrival implements ResourceInterface
+{
+    private ?object $terminal = null;
+    private ?object $gate = null;
+    private ?array $timings = null;
+
+    /**
+     * @return object|null
+     */
+    public function getTerminal(): ?object
+    {
+        return Resource::toResourceObject(
+            $this->terminal,
+            FlightPointTerminal::class
+        );
+    }
+
+    /**
+     * @return FlightPointGate|null
+     */
+    public function getGate(): ?object
+    {
+        return Resource::toResourceObject(
+            $this->gate,
+            FlightPointGate::class
+        );
+    }
+
+    /**
+     * @return FlightPointTiming[]|null
+     */
+    public function getTimings(): ?array
+    {
+        return Resource::toResourceArray(
+            $this->timings,
+            FlightPointTiming::class
+        );
+    }
+
+    public function __set($name, $value): void
+    {
+        $this->$name = $value;
+    }
+
+    public function __toString(): string
+    {
+        return Resource::toString(get_object_vars($this));
+    }
+}

--- a/src/resources/FlightPointDeparture.php
+++ b/src/resources/FlightPointDeparture.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Amadeus\Resources;
+
+/**
+ * Sub-resource in DatedFlight
+ * @see DatedFlight
+ */
+class FlightPointDeparture implements ResourceInterface
+{
+    private ?object $terminal = null;
+    private ?object $gate = null;
+    private ?array $timings = null;
+
+    /**
+     * @return object|null
+     */
+    public function getTerminal(): ?object
+    {
+        return Resource::toResourceObject(
+            $this->terminal,
+            FlightPointTerminal::class
+        );
+    }
+
+    /**
+     * @return FlightPointGate|null
+     */
+    public function getGate(): ?object
+    {
+        return Resource::toResourceObject(
+            $this->gate,
+            FlightPointGate::class
+        );
+    }
+
+    /**
+     * @return FlightPointTiming[]|null
+     */
+    public function getTimings(): ?array
+    {
+        return Resource::toResourceArray(
+            $this->timings,
+            FlightPointTiming::class
+        );
+    }
+
+    public function __set($name, $value): void
+    {
+        $this->$name = $value;
+    }
+
+    public function __toString(): string
+    {
+        return Resource::toString(get_object_vars($this));
+    }
+}

--- a/src/resources/FlightPointGate.php
+++ b/src/resources/FlightPointGate.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Amadeus\Resources;
+
+/**
+ * Sub-resource in Arrival, Departure
+ * @see FlightPointArrival, FlightPointDepartue
+ */
+class FlightPointGate implements ResourceInterface
+{
+    private ?string $mainGate = null;
+
+    /**
+     * @return string|null
+     */
+    public function getMainGate(): ?string
+    {
+        return $this->mainGate;
+    }
+
+    public function __set($name, $value): void
+    {
+        $this->$name = $value;
+    }
+
+    public function __toString(): string
+    {
+        return Resource::toString(get_object_vars($this));
+    }
+}

--- a/src/resources/FlightPointTerminal.php
+++ b/src/resources/FlightPointTerminal.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace Amadeus\Resources;
 
 /**
- * Sub-resource in FlightExtendedSegment, Leg
- * @see FlightExtendedSegment, DatedFlightLeg
+ * Sub-resource in Arrival, Departure
+ * @see FlightPointArrival, FlightPointDepartue
  */
-class AircraftEquipment implements ResourceInterface
+class FlightPointTerminal implements ResourceInterface
 {
     private ?string $code = null;
-    private ?string $aircraftType = null;
 
     /**
      * @return string|null
@@ -19,14 +18,6 @@ class AircraftEquipment implements ResourceInterface
     public function getCode(): ?string
     {
         return $this->code;
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getAircraftType(): ?string
-    {
-        return $this->aircraftType;
     }
 
     public function __set($name, $value): void

--- a/src/resources/FlightPointTiming.php
+++ b/src/resources/FlightPointTiming.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Amadeus\Resources;
+
+/**
+ * Sub-resource in Arrival, Departure
+ * @see FlightPointArrival, FlightPointDepartue
+ */
+class FlightPointTiming implements ResourceInterface
+{
+    private ?string $qualifier = null;
+    private ?string $value = null;
+    private ?array $delays = null;
+
+    /**
+     * @return string|null
+     */
+    public function getQualifier(): ?string
+    {
+        return $this->qualifier;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getValue(): ?string
+    {
+        return $this->value;
+    }
+
+    /**
+     * @return FlightPointTimingDelay[]|null
+     */
+    public function getDelays(): ?array
+    {
+        return Resource::toResourceArray(
+            $this->delays,
+            FlightPointTimingDelay::class
+        );
+    }
+
+    public function __set($name, $value): void
+    {
+        $this->$name = $value;
+    }
+
+    public function __toString(): string
+    {
+        return Resource::toString(get_object_vars($this));
+    }
+}

--- a/src/resources/FlightPointTimingDelay.php
+++ b/src/resources/FlightPointTimingDelay.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Amadeus\Resources;
+
+/**
+ * Sub-resource in Timing
+ * @see FlightPointTiming
+ */
+class FlightPointTimingDelay implements ResourceInterface
+{
+    private ?string $duration = null;
+
+    /**
+     * @return string|null
+     */
+    public function getDuration(): ?string
+    {
+        return $this->duration;
+    }
+
+    public function __set($name, $value): void
+    {
+        $this->$name = $value;
+    }
+
+    public function __toString(): string
+    {
+        return Resource::toString(get_object_vars($this));
+    }
+}

--- a/src/schedule/Flights.php
+++ b/src/schedule/Flights.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Amadeus\Schedule;
+
+use Amadeus\Amadeus;
+use Amadeus\Exceptions\ResponseException;
+use Amadeus\Resources\DatedFlight;
+use Amadeus\Resources\Resource;
+
+/**
+ * <p>
+ *   A namespaced client for the
+ *   <code>/v2/schedule/flights</code> endpoints.
+ * </p>
+ *
+ * <p>
+ *   Access via the Amadeus client object.
+ * </p>
+ *
+ * <code>
+ *  $amadeus = Amadeus::builder("clientId", "secret")->build();
+ *  $amadeus->getSchedule()->getFlights();
+ * </code>
+ */
+class Flights
+{
+    private Amadeus $amadeus;
+
+    /**
+     * Constructor
+     * @param Amadeus $amadeus
+     */
+    public function __construct(Amadeus $amadeus)
+    {
+        $this->amadeus = $amadeus;
+    }
+
+    /**
+     * ###On-Demand Flight Status API
+     * <p>
+     *    Retrieve a unique flight by search criteria..
+     * </p>
+     *
+     * <code>
+     *  $amadeus->getSchedule()->getFlights()->get(
+     *      ["carrierCode"=>"IB", "flightNumber"=>532, "scheduledDepartureDate"=>"2022-09-23"]
+     *  );
+     * </code>
+     *
+     * @see https://developers.amadeus.com/self-service/category/air/api-doc/on-demand-flight-status/api-reference
+     *
+     * @param   array $params       the parameters to send to the API
+     * @return  DatedFlight[]       an API resource
+     * @throws  ResponseException   when an exception occurs
+     */
+    public function get(array $params): array
+    {
+        $response = $this->amadeus->getClient()->getWithArrayParams(
+            '/v2/schedule/flights',
+            $params
+        );
+
+        return Resource::fromArray($response, DatedFlight::class);
+    }
+}

--- a/tests/NamespaceTest.php
+++ b/tests/NamespaceTest.php
@@ -26,6 +26,8 @@ use PHPUnit\Framework\TestCase;
  * @covers \Amadeus\ReferenceData\Locations\Hotels\ByCity
  * @covers \Amadeus\ReferenceData\Locations\Hotels\ByGeocode
  * @covers \Amadeus\ReferenceData\Locations\Hotels\ByHotels
+ * @covers \Amadeus\Schedule
+ * @covers \Amadeus\Schedule\Flights
  * @covers \Amadeus\Shopping
  * @covers \Amadeus\Shopping\Availability
  * @covers \Amadeus\Shopping\Availability\FlightAvailabilities
@@ -68,5 +70,9 @@ final class NamespaceTest extends TestCase
         $this->assertNotNull($amadeus->getReferenceData()->getLocations()->getHotels()->getByCity());
         $this->assertNotNull($amadeus->getReferenceData()->getLocations()->getHotels()->getByGeocode());
         $this->assertNotNull($amadeus->getReferenceData()->getLocations()->getHotels()->getByHotels());
+
+        // Schedule
+        $this->assertNotNull($amadeus->getSchedule());
+        $this->assertNotNull($amadeus->getSchedule()->getFlights());
     }
 }

--- a/tests/resources/__files/flights_get_response_ok.json
+++ b/tests/resources/__files/flights_get_response_ok.json
@@ -1,0 +1,65 @@
+{
+  "meta": {
+    "count": 1,
+    "links": {
+      "self": "https://test.api.amadeus.com/v2/schedule/flights?carrierCode=IB&flightNumber=532&scheduledDepartureDate=2022-09-23"
+    }
+  },
+  "data": [
+    {
+      "type": "DatedFlight",
+      "scheduledDepartureDate": "2022-09-23",
+      "flightDesignator": {
+        "carrierCode": "IB",
+        "flightNumber": 532
+      },
+      "flightPoints": [
+        {
+          "iataCode": "MAD",
+          "departure": {
+            "timings": [
+              {
+                "qualifier": "STD",
+                "value": "2022-09-23T11:45+02:00"
+              }
+            ]
+          }
+        },
+        {
+          "iataCode": "VGO",
+          "arrival": {
+            "timings": [
+              {
+                "qualifier": "STA",
+                "value": "2022-09-23T12:55+02:00"
+              }
+            ]
+          }
+        }
+      ],
+      "segments": [
+        {
+          "boardPointIataCode": "MAD",
+          "offPointIataCode": "VGO",
+          "scheduledSegmentDuration": "PT1H10M",
+          "partnership": {
+            "operatingFlight": {
+              "carrierCode": "AA",
+              "flightNumber": 8711
+            }
+          }
+        }
+      ],
+      "legs": [
+        {
+          "boardPointIataCode": "MAD",
+          "offPointIataCode": "VGO",
+          "aircraftEquipment": {
+            "aircraftType": "32A"
+          },
+          "scheduledLegDuration": "PT1H10M"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/schedule/FlightsTest.php
+++ b/tests/schedule/FlightsTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Amadeus\Tests\Schedule;
+
+use Amadeus\Amadeus;
+use Amadeus\Client\HTTPClient;
+use Amadeus\Client\Response;
+use Amadeus\Exceptions\ResponseException;
+use Amadeus\Resources\AircraftEquipment;
+use Amadeus\Resources\DatedFlight;
+use Amadeus\Resources\DatedFlightLeg;
+use Amadeus\Resources\DatedFlightSegment;
+use Amadeus\Resources\DatedFlightSegmentPartnership;
+use Amadeus\Resources\FlightDesignator;
+use Amadeus\Resources\FlightPoint;
+use Amadeus\Resources\FlightPointArrival;
+use Amadeus\Resources\FlightPointDeparture;
+use Amadeus\Resources\FlightPointTiming;
+use Amadeus\Schedule\Flights;
+use Amadeus\Tests\PHPUnitUtil;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * This test covers the endpoint and its related returned resources.
+ * @covers \Amadeus\Schedule\Flights
+ *
+ * @covers \Amadeus\Resources\Resource
+ * @covers \Amadeus\Resources\AircraftEquipment
+ * @covers \Amadeus\Resources\DatedFlight
+ * @covers \Amadeus\Resources\DatedFlightLeg
+ * @covers \Amadeus\Resources\DatedFlightSegment
+ * @covers \Amadeus\Resources\DatedFlightSegmentPartnership
+ * @covers \Amadeus\Resources\FlightDesignator
+ * @covers \Amadeus\Resources\FlightPoint
+ * @covers \Amadeus\Resources\FlightPointArrival
+ * @covers \Amadeus\Resources\FlightPointDeparture
+ * @covers \Amadeus\Resources\FlightPointTiming
+ * @covers \Amadeus\Schedule\Flights
+ *
+ * @see https://developers.amadeus.com/self-service/category/air/api-doc/on-demand-flight-status/api-reference
+ */
+final class FlightsTest extends TestCase
+{
+    private Amadeus $amadeus;
+    private HTTPClient $client;
+
+    /**
+     * @Before
+     */
+    public function setUp(): void
+    {
+        // Mock an Amadeus with HTTPClient
+        $this->amadeus = $this->createMock(Amadeus::class);
+        $this->client = $this->createMock(HTTPClient::class);
+        $this->amadeus->expects($this->any())
+            ->method("getClient")
+            ->willReturn($this->client);
+    }
+
+    /**
+     * @throws ResponseException
+     */
+    public function test_given_client_when_call_flights_then_ok(): void
+    {
+        // Prepare Response
+        $fileContent = PHPUnitUtil::readFile(
+            PHPUnitUtil::RESOURCE_PATH_ROOT . "flights_get_response_ok.json"
+        );
+        $data = json_decode($fileContent)->{'data'};
+        $response = $this->createMock(Response::class);
+        $response->expects($this->any())
+            ->method("getData")
+            ->willReturn($data);
+
+        // Given
+        $params = ["carrierCode"=>"IB", "flightNumber"=>532, "scheduledDepartureDate"=>"2022-09-23"];
+        /* @phpstan-ignore-next-line */
+        $this->client->expects($this->any())
+            ->method("getWithArrayParams")
+            ->with("/v2/schedule/flights", $params)
+            ->willReturn($response);
+
+        // When
+        $flights = (new Flights($this->amadeus))->get($params);
+
+        // Then
+        $this->assertNotNull($flights);
+        $this->assertEquals(1, sizeof($flights));
+
+        // Resources
+        // DatedFlight
+        $this->assertTrue($flights[0] instanceof DatedFlight);
+        $this->assertEquals("DatedFlight", $flights[0]->getType());
+        $this->assertEquals("2022-09-23", $flights[0]->getScheduledDepartureDate());
+
+        // FlightDesignator
+        $flightDesignator = $flights[0]->getFlightDesignator();
+        $this->assertTrue($flightDesignator instanceof FlightDesignator);
+        $this->assertEquals("IB", $flightDesignator->getCarrierCode());
+        $this->assertEquals(532, $flightDesignator->getFlightNumber());
+
+        // FlightPoint
+        $flightPoints = $flights[0]->getFlightPoints();
+        $this->assertTrue($flightPoints[0] instanceof FlightPoint);
+        $this->assertEquals("MAD", $flightPoints[0]->getIataCode());
+
+        // FlightPointDeparture
+        $departure = $flightPoints[0]->getDeparture();
+        $this->assertTrue($departure instanceof FlightPointDeparture);
+
+        // FlightPointArrival
+        $arrival = $flightPoints[1]->getArrival();
+        $this->assertTrue($arrival instanceof FlightPointArrival);
+
+        // FlightPointTiming
+        $departureTiming = $departure->getTimings();
+        $arrivalTiming = $arrival->getTimings();
+        $this->assertTrue($departureTiming[0] instanceof FlightPointTiming);
+        $this->assertTrue($arrivalTiming[0] instanceof FlightPointTiming);
+        $this->assertEquals("STD", $departureTiming[0]->getQualifier());
+        $this->assertEquals("2022-09-23T11:45+02:00", $departureTiming[0]->getValue());
+
+        // DatedFlightSegment
+        $segments = $flights[0]->getSegments();
+        $this->assertTrue($segments[0] instanceof DatedFlightSegment);
+        $this->assertEquals("MAD", $segments[0]->getBoardPointIataCode());
+        $this->assertEquals("VGO", $segments[0]->getOffPointIataCode());
+        $this->assertEquals("PT1H10M", $segments[0]->getScheduledSegmentDuration());
+
+        // DatedFlightSegmentPartnership
+        $partnership = $segments[0]->getPartnership();
+        $this->assertTrue($partnership instanceof DatedFlightSegmentPartnership);
+        $this->assertTrue($partnership->getOperatingFlight() instanceof FlightDesignator);
+
+        // DatedFlightLeg
+        $legs = $flights[0]->getLegs();
+        $this->assertTrue($legs[0] instanceof DatedFlightLeg);
+        $this->assertEquals("MAD", $legs[0]->getBoardPointIataCode());
+        $this->assertEquals("VGO", $legs[0]->getOffPointIataCode());
+        $this->assertEquals("PT1H10M", $legs[0]->getScheduledLegDuration());
+
+        // AircraftEquipment
+        $aircraftEquipment = $legs[0]->getAircraftEquipment();
+        $this->assertTrue($aircraftEquipment instanceof AircraftEquipment);
+        $this->assertEquals("32A", $aircraftEquipment->getAircraftType());
+
+        // __toString()
+        $this->assertEquals(
+            PHPUnitUtil::toString($data[0]),
+            $flights[0]->__toString()
+        );
+        $this->assertEquals(
+            PHPUnitUtil::toString($data[0]->{'flightDesignator'}),
+            $flightDesignator->__toString()
+        );
+        $this->assertEquals(
+            PHPUnitUtil::toString($data[0]->{'flightPoints'}[0]),
+            $flightPoints[0]->__toString()
+        );
+        $this->assertEquals(
+            PHPUnitUtil::toString($data[0]->{'flightPoints'}[0]->{'departure'}),
+            $departure->__toString()
+        );
+        $this->assertEquals(
+            PHPUnitUtil::toString($data[0]->{'flightPoints'}[1]->{'arrival'}),
+            $arrival->__toString()
+        );
+        $this->assertEquals(
+            PHPUnitUtil::toString($data[0]->{'flightPoints'}[0]->{'departure'}->{'timings'}[0]),
+            $departureTiming[0]->__toString()
+        );
+        $this->assertEquals(
+            PHPUnitUtil::toString($data[0]->{'segments'}[0]),
+            $segments[0]->__toString()
+        );
+        $this->assertEquals(
+            PHPUnitUtil::toString($data[0]->{'segments'}[0]->{'partnership'}),
+            $partnership->__toString()
+        );
+        $this->assertEquals(
+            PHPUnitUtil::toString($data[0]->{'legs'}[0]),
+            $legs[0]->__toString()
+        );
+    }
+}


### PR DESCRIPTION
Fixes #32 

- [x] Resource Model - ```DatedFlight.php```
- [x] Namespace Client and API support - ```$amadeus->getSchedule()->getFlights()->get($params)```
- [x] Namespace Test - ```NamespaceTest.php```
- [x] Endpoint and Resource Test - ```FlightsTest.php```
