### PR TITLE
add support for Airport Nearest Relevant API

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,10 @@ $amadeus->getAirport()->getDirectDestinations()->get(["departureAirportCode" => 
 /* Flight Cheapest Date Search */
 // function get(array $params) :
 $amadeus->getShopping()->getFlightDates()->get(["origin"=>"MAD", "destination"=>"LON"]);
+
+/* Airport Nearest Relevant */
+// function get(array $params) :
+$amadeus->getReferenceData()->getLocations()->getAirports()->get(["latitude"=>51.57285, "longitude"=>-0.44161, "radius"=>500]);
 ```
 
 ## Development & Contributing

--- a/src/referenceData/Locations.php
+++ b/src/referenceData/Locations.php
@@ -6,6 +6,7 @@ namespace Amadeus\ReferenceData;
 
 use Amadeus\Amadeus;
 use Amadeus\Exceptions\ResponseException;
+use Amadeus\ReferenceData\Locations\Airports;
 use Amadeus\ReferenceData\Locations\Hotel;
 use Amadeus\ReferenceData\Locations\Hotels;
 use Amadeus\Resources\Location;
@@ -47,6 +48,14 @@ class Locations
     private Hotel $hotel;
 
     /**
+     * <p>
+     *   A namespaced client for the
+     *   <code>/v1/reference-data/locations/airports</code> endpoints.
+     * </p>
+     */
+    private Airports $airports;
+
+    /**
      * @param Amadeus $amadeus
      */
     public function __construct(Amadeus $amadeus)
@@ -54,6 +63,7 @@ class Locations
         $this->amadeus = $amadeus;
         $this->hotels = new Hotels($amadeus);
         $this->hotel = new Hotel($amadeus);
+        $this->airports = new Airports($amadeus);
     }
 
     /**
@@ -78,6 +88,18 @@ class Locations
     public function getHotel(): Hotel
     {
         return $this->hotel;
+    }
+
+    /**
+     * <p>
+     *   Get a namespaced client for the
+     *   <code>/v1/reference-data/locations/airports</code> endpoints.
+     * </p>
+     * @return Airports
+     */
+    public function getAirports(): Airports
+    {
+        return $this->airports;
     }
 
     /**

--- a/src/referenceData/locations/Airports.php
+++ b/src/referenceData/locations/Airports.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Amadeus\ReferenceData\Locations;
+
+use Amadeus\Amadeus;
+use Amadeus\Exceptions\ResponseException;
+use Amadeus\Resources\Location;
+use Amadeus\Resources\Resource;
+
+/**
+ * <p>
+ *   A namespaced client for the
+ *   <code>/v1/reference-data/locations/airports</code> endpoints.
+ * </p>
+ *
+ * <p>
+ *   Access via the Amadeus client object.
+ * </p>
+ *
+ * <code>
+ *  $amadeus = Amadeus::builder("clientId", "secret")->build();
+ *  $amadeus->getReferenceData()->getLocations()->getAirports();
+ * </code>
+ */
+class Airports
+{
+    private Amadeus $amadeus;
+
+    /**
+     * @param Amadeus $amadeus
+     */
+    public function __construct(Amadeus $amadeus)
+    {
+        $this->amadeus = $amadeus;
+    }
+
+    /**
+     * ###Airport Nearest Relevant API
+     *
+     * @see https://developers.amadeus.com/self-service/category/air/api-doc/airport-nearest-relevant/api-reference
+     *
+     * @param array $params
+     * @return Location[]
+     * @throws ResponseException
+     */
+    public function get(array $params): array
+    {
+        $response = $this->amadeus->getClient()->getWithArrayParams(
+            '/v1/reference-data/locations/airports',
+            $params
+        );
+
+        return Resource::fromArray($response, Location::class);
+    }
+}

--- a/tests/NamespaceTest.php
+++ b/tests/NamespaceTest.php
@@ -21,6 +21,7 @@ use PHPUnit\Framework\TestCase;
  * @covers \Amadeus\Booking\HotelBookings
  * @covers \Amadeus\ReferenceData
  * @covers \Amadeus\ReferenceData\Locations
+ * @covers \Amadeus\ReferenceData\Locations\Airports
  * @covers \Amadeus\ReferenceData\Locations\Hotel
  * @covers \Amadeus\ReferenceData\Locations\Hotels
  * @covers \Amadeus\ReferenceData\Locations\Hotels\ByCity
@@ -68,5 +69,6 @@ final class NamespaceTest extends TestCase
         $this->assertNotNull($amadeus->getReferenceData()->getLocations()->getHotels()->getByCity());
         $this->assertNotNull($amadeus->getReferenceData()->getLocations()->getHotels()->getByGeocode());
         $this->assertNotNull($amadeus->getReferenceData()->getLocations()->getHotels()->getByHotels());
+        $this->assertNotNull($amadeus->getReferenceData()->getLocations()->getAirports());
     }
 }

--- a/tests/referenceData/LocationsTest.php
+++ b/tests/referenceData/LocationsTest.php
@@ -26,6 +26,7 @@ use PHPUnit\Framework\TestCase;
  * @covers \Amadeus\ReferenceData\Locations\Hotels\ByCity
  * @covers \Amadeus\ReferenceData\Locations\Hotels\ByGeocode
  * @covers \Amadeus\ReferenceData\Locations\Hotels\ByHotels
+ * @covers \Amadeus\ReferenceData\Locations\Airports
  *
  * @covers \Amadeus\Resources\LocationAddress
  * @covers \Amadeus\Resources\LocationAnalytics

--- a/tests/referenceData/locations/AirportsTest.php
+++ b/tests/referenceData/locations/AirportsTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Amadeus\Tests\ReferenceData\Locations;
+
+use Amadeus\Amadeus;
+use Amadeus\Client\HTTPClient;
+use Amadeus\Client\Response;
+use Amadeus\Exceptions\ResponseException;
+use Amadeus\ReferenceData\Locations\Airports;
+use Amadeus\Resources\LocationDistance;
+use Amadeus\Tests\PHPUnitUtil;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * This test covers the endpoint and its related returned resources.
+ * @covers \Amadeus\ReferenceData\Locations\Airports
+ *
+ * @covers \Amadeus\Resources\Resource
+ * @covers \Amadeus\Resources\Location
+ * @covers \Amadeus\Resources\LocationDistance
+ *
+ * @see https://developers.amadeus.com/self-service/category/air/api-doc/airport-nearest-relevant/api-reference
+ */
+final class AirportsTest extends TestCase
+{
+    private Amadeus $amadeus;
+    private HTTPClient $client;
+
+    /**
+     * @Before
+     */
+    public function setUp(): void
+    {
+        // Mock an Amadeus with HTTPClient
+        $this->amadeus = $this->createMock(Amadeus::class);
+        $this->client = $this->createMock(HTTPClient::class);
+        $this->amadeus->expects($this->any())
+            ->method("getClient")
+            ->willReturn($this->client);
+    }
+
+    /**
+     * @throws ResponseException
+     */
+    public function test_given_client_when_call_airports_then_ok(): void
+    {
+        // Prepare Response
+        $fileContent = PHPUnitUtil::readFile(
+            PHPUnitUtil::RESOURCE_PATH_ROOT . "airports_get_response_ok.json"
+        );
+        $data = json_decode($fileContent)->{'data'};
+        $response = $this->createMock(Response::class);
+        $response->expects($this->any())
+            ->method("getData")
+            ->willReturn($data);
+
+        // Given
+        $params = ["latitude"=>51.57285, "longitude"=>-0.44161, "radius"=>500];
+        /* @phpstan-ignore-next-line */
+        $this->client->expects($this->any())
+            ->method("getWithArrayParams")
+            ->with("/v1/reference-data/locations/airports", $params)
+            ->willReturn($response);
+
+        // When
+        $airports = (new Airports($this->amadeus))->get($params);
+
+        // Then
+        $this->assertNotNull($airports);
+        $this->assertEquals(10, sizeof($airports));
+
+        // Resources
+        // Location
+        // Most of the properties in Location Resource Model have been tested in LocationsTest.php
+        // In this test, only test the missing part
+        $this->assertEquals(350.54587, $airports[0]->getRelevance());
+
+        // LocationDistance
+        $distance = $airports[0]->getDistance();
+        $this->assertTrue($distance instanceof LocationDistance);
+        $this->assertEquals("11", $distance->getValue());
+        $this->assertEquals("KM", $distance->getUnit());
+
+        // __toString()
+        $this->assertEquals(
+            PHPUnitUtil::toString($data[0]),
+            $airports[0]->__toString()
+        );
+        $this->assertEquals(
+            PHPUnitUtil::toString($data[0]->{'distance'}),
+            $distance->__toString()
+        );
+    }
+}

--- a/tests/resources/__files/airports_get_response_ok.json
+++ b/tests/resources/__files/airports_get_response_ok.json
@@ -1,0 +1,332 @@
+{
+  "meta": {
+    "count": 31,
+    "links": {
+      "self": "https://test.api.amadeus.com/v1/reference-data/locations/airports?latitude=51.57285&longitude=-0.44161&radius=500",
+      "next": "https://test.api.amadeus.com/v1/reference-data/locations/airports?latitude=51.57285&longitude=-0.44161&radius=500&page%5Boffset%5D=10",
+      "last": "https://test.api.amadeus.com/v1/reference-data/locations/airports?latitude=51.57285&longitude=-0.44161&radius=500&page%5Boffset%5D=21"
+    }
+  },
+  "data": [
+    {
+      "type": "location",
+      "subType": "AIRPORT",
+      "name": "HEATHROW",
+      "detailedName": "LONDON/GB:HEATHROW",
+      "timeZoneOffset": "+01:00",
+      "iataCode": "LHR",
+      "geoCode": {
+        "latitude": 51.47294,
+        "longitude": -0.45061
+      },
+      "address": {
+        "cityName": "LONDON",
+        "cityCode": "LON",
+        "countryName": "UNITED KINGDOM",
+        "countryCode": "GB",
+        "regionCode": "EUROP"
+      },
+      "distance": {
+        "value": 11,
+        "unit": "KM"
+      },
+      "analytics": {
+        "flights": {
+          "score": 39
+        },
+        "travelers": {
+          "score": 45
+        }
+      },
+      "relevance": 350.54587
+    },
+    {
+      "type": "location",
+      "subType": "AIRPORT",
+      "name": "GATWICK",
+      "detailedName": "LONDON/GB:GATWICK",
+      "timeZoneOffset": "+01:00",
+      "iataCode": "LGW",
+      "geoCode": {
+        "latitude": 51.15609,
+        "longitude": -0.17818
+      },
+      "address": {
+        "cityName": "LONDON",
+        "cityCode": "LON",
+        "countryName": "UNITED KINGDOM",
+        "countryCode": "GB",
+        "regionCode": "EUROP"
+      },
+      "distance": {
+        "value": 49,
+        "unit": "KM"
+      },
+      "analytics": {
+        "flights": {
+          "score": 27
+        },
+        "travelers": {
+          "score": 27
+        }
+      },
+      "relevance": 53.62667
+    },
+    {
+      "type": "location",
+      "subType": "AIRPORT",
+      "name": "LUTON",
+      "detailedName": "LONDON/GB:LUTON",
+      "timeZoneOffset": "+01:00",
+      "iataCode": "LTN",
+      "geoCode": {
+        "latitude": 51.87472,
+        "longitude": -0.36833
+      },
+      "address": {
+        "cityName": "LONDON",
+        "cityCode": "LON",
+        "countryName": "UNITED KINGDOM",
+        "countryCode": "GB",
+        "regionCode": "EUROP"
+      },
+      "distance": {
+        "value": 33,
+        "unit": "KM"
+      },
+      "analytics": {
+        "flights": {
+          "score": 11
+        },
+        "travelers": {
+          "score": 10
+        }
+      },
+      "relevance": 33.10184
+    },
+    {
+      "type": "location",
+      "subType": "AIRPORT",
+      "name": "STANSTED",
+      "detailedName": "LONDON/GB:STANSTED",
+      "timeZoneOffset": "+01:00",
+      "iataCode": "STN",
+      "geoCode": {
+        "latitude": 51.885,
+        "longitude": 0.235
+      },
+      "address": {
+        "cityName": "LONDON",
+        "cityCode": "LON",
+        "countryName": "UNITED KINGDOM",
+        "countryCode": "GB",
+        "regionCode": "EUROP"
+      },
+      "distance": {
+        "value": 58,
+        "unit": "KM"
+      },
+      "analytics": {
+        "flights": {
+          "score": 16
+        },
+        "travelers": {
+          "score": 15
+        }
+      },
+      "relevance": 27.50241
+    },
+    {
+      "type": "location",
+      "subType": "AIRPORT",
+      "name": "CITY AIRPORT",
+      "detailedName": "LONDON/GB:CITY AIRPORT",
+      "timeZoneOffset": "+01:00",
+      "iataCode": "LCY",
+      "geoCode": {
+        "latitude": 51.50528,
+        "longitude": 0.05528
+      },
+      "address": {
+        "cityName": "LONDON",
+        "cityCode": "LON",
+        "countryName": "UNITED KINGDOM",
+        "countryCode": "GB",
+        "regionCode": "EUROP"
+      },
+      "distance": {
+        "value": 35,
+        "unit": "KM"
+      },
+      "analytics": {
+        "flights": {
+          "score": 8
+        },
+        "travelers": {
+          "score": 4
+        }
+      },
+      "relevance": 21.78754
+    },
+    {
+      "type": "location",
+      "subType": "AIRPORT",
+      "name": "BIRMINGHAM",
+      "detailedName": "BIRMINGHAM/GB:BIRMINGHAM",
+      "timeZoneOffset": "+01:00",
+      "iataCode": "BHX",
+      "geoCode": {
+        "latitude": 52.45386,
+        "longitude": -1.74803
+      },
+      "address": {
+        "cityName": "BIRMINGHAM",
+        "cityCode": "BHX",
+        "countryName": "UNITED KINGDOM",
+        "countryCode": "GB",
+        "regionCode": "EUROP"
+      },
+      "distance": {
+        "value": 132,
+        "unit": "KM"
+      },
+      "analytics": {
+        "flights": {
+          "score": 10
+        },
+        "travelers": {
+          "score": 8
+        }
+      },
+      "relevance": 7.73356
+    },
+    {
+      "type": "location",
+      "subType": "AIRPORT",
+      "name": "MANCHESTER AIRPORT",
+      "detailedName": "MANCHESTER/GB:MANCHESTER AIRPO",
+      "timeZoneOffset": "+01:00",
+      "iataCode": "MAN",
+      "geoCode": {
+        "latitude": 53.35374,
+        "longitude": -2.27495
+      },
+      "address": {
+        "cityName": "MANCHESTER",
+        "cityCode": "MAN",
+        "countryName": "UNITED KINGDOM",
+        "countryCode": "GB",
+        "regionCode": "EUROP"
+      },
+      "distance": {
+        "value": 233,
+        "unit": "KM"
+      },
+      "analytics": {
+        "flights": {
+          "score": 18
+        },
+        "travelers": {
+          "score": 17
+        }
+      },
+      "relevance": 7.71084
+    },
+    {
+      "type": "location",
+      "subType": "AIRPORT",
+      "name": "SOUTHAMPTON",
+      "detailedName": "SOUTHAMPTON/GB",
+      "timeZoneOffset": "+01:00",
+      "iataCode": "SOU",
+      "geoCode": {
+        "latitude": 50.95026,
+        "longitude": -1.3568
+      },
+      "address": {
+        "cityName": "SOUTHAMPTON",
+        "cityCode": "SOU",
+        "countryName": "UNITED KINGDOM",
+        "countryCode": "GB",
+        "regionCode": "EUROP"
+      },
+      "distance": {
+        "value": 94,
+        "unit": "KM"
+      },
+      "analytics": {
+        "flights": {
+          "score": 4
+        },
+        "travelers": {
+          "score": 2
+        }
+      },
+      "relevance": 4.4788
+    },
+    {
+      "type": "location",
+      "subType": "AIRPORT",
+      "name": "BRISTOL",
+      "detailedName": "BRISTOL/GB:BRISTOL",
+      "timeZoneOffset": "+01:00",
+      "iataCode": "BRS",
+      "geoCode": {
+        "latitude": 51.38267,
+        "longitude": -2.71909
+      },
+      "address": {
+        "cityName": "BRISTOL",
+        "cityCode": "BRS",
+        "countryName": "UNITED KINGDOM",
+        "countryCode": "GB",
+        "regionCode": "EUROP"
+      },
+      "distance": {
+        "value": 159,
+        "unit": "KM"
+      },
+      "analytics": {
+        "flights": {
+          "score": 7
+        },
+        "travelers": {
+          "score": 5
+        }
+      },
+      "relevance": 4.08617
+    },
+    {
+      "type": "location",
+      "subType": "AIRPORT",
+      "name": "EAST MIDLANDS",
+      "detailedName": "NOTTINGHAM/GB:EAST MIDLANDS",
+      "timeZoneOffset": "+01:00",
+      "iataCode": "EMA",
+      "geoCode": {
+        "latitude": 52.83111,
+        "longitude": -1.32806
+      },
+      "address": {
+        "cityName": "NOTTINGHAM",
+        "cityCode": "NQT",
+        "countryName": "UNITED KINGDOM",
+        "countryCode": "GB",
+        "regionCode": "EUROP"
+      },
+      "distance": {
+        "value": 152,
+        "unit": "KM"
+      },
+      "analytics": {
+        "flights": {
+          "score": 4
+        },
+        "travelers": {
+          "score": 3
+        }
+      },
+      "relevance": 2.66099
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #33 

- [x] Resource Model - ```Location.php``` (**EXISTED**)
- [x] Namespace Client and API support - ```$amadeus->getReferenceData()->getAirports()->get($params)```
- [x] Namespace Test - ```NamespaceTest.php```
- [x] Endpoint and Resource Test - ```AirportsTest.php```

