### PR TITLE
add support for Flight Choice Prediction API

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,13 @@ $amadeus->getBooking()->getFlightOrders()->post($body);
 // function postWithFlightOffersAndTravelers(array $flightOffers, array $travelers);
 $amadeus->getBooking()->getFlightOrders()->postWithFlightOffersAndTravelers($flightOffers, $travelers);
 
+/* Flight Choice Prediction */
+// function post(string $body) :
+$amadeus->getShopping()->getFlightOffers()->getPrediction()->post($body);
+// function postWithFlightOffers(array $flightOffers) : 
+$flightOffers = $this->getShopping()->getFlightOffers()->get(["originLocationCode"=>"LON", "destinationLocationCode"=>"NYC", "departureDate"=>"2022-12-06", "adults"=>1, "max"=>20]);
+$amadeus->getShopping()->getFlightOffers()->getPrediction()->postWithFlightOffers($flightOffers);
+
 /* Airport and City Search (autocomplete) */
 // Get a list of airports and cities matching a given keyword
 // function get(array $params) :

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -12,9 +12,12 @@ class Constants
 
     // APIs which need an X-HTTP-Method-Override GET HEADER
     public const API_NEED_EXTRA_HEADER = array(
-        "/v1/shopping/availability/flight-availabilities",
-        "/v1/shopping/flight-offers",
-        "/v1/shopping/flight-offers/pricing"
+        '/v2/shopping/flight-offers',
+        '/v1/shopping/seatmaps',
+        '/v1/shopping/availability/flight-availabilities',
+        '/v2/shopping/flight-offers/prediction',
+        '/v1/shopping/flight-offers/pricing',
+        '/v1/shopping/flight-offers/upselling'
     );
 
     public const HTTPS = "https";

--- a/src/resources/Description.php
+++ b/src/resources/Description.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Amadeus\Resources;
+
+/**
+ * Sub-resource in TermAnaCondition
+ * @see TermAndCondition
+ */
+class Description implements ResourceInterface
+{
+    private ?string $descriptionType = null;
+    private ?string $text = null;
+
+    /**
+     * @return string|null
+     */
+    public function getDescriptionType(): ?string
+    {
+        return $this->descriptionType;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getText(): ?string
+    {
+        return $this->text;
+    }
+
+    public function __set($name, $value): void
+    {
+        $this->$name = $value;
+    }
+
+    public function __toString(): string
+    {
+        return Resource::toString(get_object_vars($this));
+    }
+}

--- a/src/resources/FareRules.php
+++ b/src/resources/FareRules.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Amadeus\Resources;
+
+/**
+ * Sub-resource in FlightOffer
+ * @see FlightOffer
+ */
+class FareRules implements ResourceInterface
+{
+    private ?string $currency = null;
+    private ?array $rules = null;
+
+    /**
+     * @return string|null
+     */
+    public function getCurrency(): ?string
+    {
+        return $this->currency;
+    }
+
+    /**
+     * @return TermAndCondition[]|null
+     */
+    public function getRules(): ?array
+    {
+        return Resource::toResourceArray(
+            $this->rules,
+            TermAndCondition::class
+        );
+    }
+
+    public function __set($name, $value): void
+    {
+        $this->$name = $value;
+    }
+
+    public function __toString(): string
+    {
+        return Resource::toString(get_object_vars($this));
+    }
+}

--- a/src/resources/FlightOffer.php
+++ b/src/resources/FlightOffer.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace Amadeus\Resources;
 
 /**
- * A FlightOffer object as returned by the Flight Offers Search API.
- * @see FlightOffers
+ * A FlightOffer object as returned by the Flight Offers Search API, Flight Choice Prediction API.
+ * @see FlightOffers, Prediction
  * @see https://developers.amadeus.com/self-service/category/air/api-doc/flight-offers-search/api-reference
+ * @see https://developers.amadeus.com/self-service/category/air/api-doc/flight-choice-prediction/api-reference
  */
 class FlightOffer extends Resource implements ResourceInterface
 {
@@ -26,6 +27,8 @@ class FlightOffer extends Resource implements ResourceInterface
     private ?array $validatingAirlineCodes = null;
     private ?array $travelerPricings = null;
     private ?bool $paymentCardRequired = null;
+    private ?string $choiceProbability = null;
+    private ?object $fareRules = null;
 
     /**
      * @return string|null
@@ -156,6 +159,25 @@ class FlightOffer extends Resource implements ResourceInterface
         return Resource::toResourceArray(
             $this->travelerPricings,
             TravelerPricing::class
+        );
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getChoiceProbability(): ?string
+    {
+        return $this->choiceProbability;
+    }
+
+    /**
+     * @return FareRules|null
+     */
+    public function getFareRules(): ?object
+    {
+        return Resource::toResourceObject(
+            $this->fareRules,
+            FareRules::class
         );
     }
 

--- a/src/resources/TermAndCondition.php
+++ b/src/resources/TermAndCondition.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Amadeus\Resources;
+
+/**
+ * Sub-resource in FareRules
+ * @see FareRules
+ */
+class TermAndCondition implements ResourceInterface
+{
+    private ?string $category = null;
+    private ?string $circumstances = null;
+    private ?bool $notApplicable = null;
+    private ?string $maxPenaltyAmount = null;
+    private ?array $descriptions = null;
+
+    /**
+     * @return string|null
+     */
+    public function getCategory(): ?string
+    {
+        return $this->category;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getCircumstances(): ?string
+    {
+        return $this->circumstances;
+    }
+
+    /**
+     * @return bool|null
+     */
+    public function getNotApplicable(): ?bool
+    {
+        return $this->notApplicable;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getMaxPenaltyAmount(): ?string
+    {
+        return $this->maxPenaltyAmount;
+    }
+
+    /**
+     * @return Description[]|null
+     */
+    public function getDescriptions(): ?array
+    {
+        return Resource::toResourceArray(
+            $this->descriptions,
+            Description::class
+        );
+    }
+
+
+    public function __set($name, $value): void
+    {
+        $this->$name = $value;
+    }
+
+    public function __toString(): string
+    {
+        return Resource::toString(get_object_vars($this));
+    }
+}

--- a/src/shopping/FlightOffers.php
+++ b/src/shopping/FlightOffers.php
@@ -8,6 +8,7 @@ use Amadeus\Amadeus;
 use Amadeus\Exceptions\ResponseException;
 use Amadeus\Resources\FlightOffer;
 use Amadeus\Resources\Resource;
+use Amadeus\Shopping\FlightOffers\Prediction;
 use Amadeus\Shopping\FlightOffers\Pricing;
 
 /**
@@ -38,12 +39,21 @@ class FlightOffers
     private Pricing $pricing;
 
     /**
+     * <p>
+     *   A namespaced client for the
+     *   <code>/v2/shopping/flight-offers/prediction</code> endpoints.
+     * </p>
+     */
+    private Prediction $prediction;
+
+    /**
      * @param Amadeus $amadeus
      */
     public function __construct(Amadeus $amadeus)
     {
         $this->amadeus = $amadeus;
         $this->pricing = new Pricing($amadeus);
+        $this->prediction = new Prediction($amadeus);
     }
 
     /**
@@ -56,6 +66,18 @@ class FlightOffers
     public function getPricing(): Pricing
     {
         return $this->pricing;
+    }
+
+    /**
+     * <p>
+     *   Get a namespaced client for the
+     *   <code>/v2/shopping/flight-offers/prediction</code> endpoints.
+     * </p>
+     * @return Prediction
+     */
+    public function getPrediction(): Prediction
+    {
+        return $this->prediction;
     }
 
     /**

--- a/src/shopping/flightOffers/Prediction.php
+++ b/src/shopping/flightOffers/Prediction.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Amadeus\Shopping\FlightOffers;
+
+use Amadeus\Amadeus;
+use Amadeus\Exceptions\ResponseException;
+use Amadeus\Resources\FlightOffer;
+use Amadeus\Resources\Resource;
+
+/**
+ * <p>
+ *   A namespaced client for the
+ *   <code>/v2/shopping/flight-offers/prediction</code> endpoints.
+ * </p>
+ *
+ * <p>
+ *   Access via the Amadeus client object.
+ * </p>
+ *
+ * <code>
+ *  $amadeus = Amadeus::builder("clientId", "secret")->build();
+ *  $amadeus->getShopping()->getFlightOffers()->getPrediction();
+ * </code>
+ */
+class Prediction
+{
+    private Amadeus $amadeus;
+
+    /**
+     * Constructor
+     * @param Amadeus $amadeus
+     */
+    public function __construct(Amadeus $amadeus)
+    {
+        $this->amadeus = $amadeus;
+    }
+
+    /**
+     * ###Flight Choice Prediction API
+     * <p>
+     * This Machine Learning API is based on a prediction model that takes the response of a flight
+     * search as input (Flight Offers Search) and predicts, for each itinerary, the probability to
+     * be selected.
+     * </p>
+     *
+     * <code>
+     *  $amadeus->getShopping()->getFlightOffers()->getPrediction()->post($body);
+     * </code>
+     *
+     * @see https://developers.amadeus.com/self-service/category/air/api-doc/flight-choice-prediction/api-reference
+     *
+     * @param string $body                  JSON body of flight offers as String to price
+     * @return FlightOffer[]                an API resource
+     * @throws ResponseException            when an exception occurs
+     */
+    public function post(string $body): array
+    {
+        $response = $this->amadeus->getClient()->postWithStringBody(
+            '/v2/shopping/flight-offers/prediction',
+            $body
+        );
+
+        return Resource::fromArray($response, FlightOffer::class);
+    }
+
+    /**
+     * ###Flight Choice Prediction API
+     * <p>
+     * This Machine Learning API is based on a prediction model that takes the response of a flight
+     * search as input (Flight Offers Search) and predicts, for each itinerary, the probability to
+     * be selected.
+     * </p>
+     *
+     * <code>
+     *  $flightOffers = $amadeus->getShopping()->getFlightOffers()->get($params);
+     *  $amadeus->getShopping()->getFlightOffers()->getPrediction()->postWithFlightOffers($flightOffers);
+     * </code>
+     *
+     * @see https://developers.amadeus.com/self-service/category/air/api-doc/flight-choice-prediction/api-reference
+     * @param array $flightOffers           Lists of flight offers as FlightOffer[]
+     * @return FlightOffer[]                an API resource
+     * @throws ResponseException            when an exception occurs
+     */
+    public function postWithFlightOffers(array $flightOffers): array
+    {
+        $flightOffersArray = array();
+        foreach ($flightOffers as $flightOffer) {
+            $flightOffersArray[] = json_decode((string)$flightOffer);
+        }
+
+        // Prepare JSON object
+        $flightOffersInput = (object)[
+            "data" => $flightOffersArray
+        ];
+
+        $body = Resource::toString(get_object_vars($flightOffersInput));
+
+        return $this->post($body);
+    }
+}

--- a/tests/NamespaceTest.php
+++ b/tests/NamespaceTest.php
@@ -40,6 +40,7 @@ use PHPUnit\Framework\TestCase;
  * @covers \Amadeus\Shopping\FlightDates
  * @covers \Amadeus\Shopping\FlightOffers
  * @covers \Amadeus\Shopping\FlightOffers\Pricing
+ * @covers \Amadeus\Shopping\FlightOffers\Prediction
  * @covers \Amadeus\Shopping\HotelOffer
  * @covers \Amadeus\Shopping\HotelOffers
  * @covers \Amadeus\Travel
@@ -73,6 +74,7 @@ final class NamespaceTest extends TestCase
         $this->assertNotNull($amadeus->getShopping()->getAvailability()->getFlightAvailabilities());
         $this->assertNotNull($amadeus->getShopping()->getFlightOffers());
         $this->assertNotNull($amadeus->getShopping()->getFlightOffers()->getPricing());
+        $this->assertNotNull($amadeus->getShopping()->getFlightOffers()->getPrediction());
         $this->assertNotNull($amadeus->getShopping()->getHotelOffer("XXX"));
         $this->assertNotNull($amadeus->getShopping()->getHotelOffers());
         $this->assertNotNull($amadeus->getShopping()->getFlightDates());

--- a/tests/resources/__files/flight_choice_prediction_post_request_ok.json
+++ b/tests/resources/__files/flight_choice_prediction_post_request_ok.json
@@ -1,0 +1,472 @@
+{
+    "data": [
+        {
+            "type": "flight-offer",
+            "id": "1",
+            "source": "GDS",
+            "instantTicketingRequired": false,
+            "nonHomogeneous": false,
+            "oneWay": false,
+            "lastTicketingDate": "2020-01-16",
+            "numberOfBookableSeats": 7,
+            "itineraries": [
+                {
+                    "duration": "PT15H55M",
+                    "segments": [
+                        {
+                            "departure": {
+                                "iataCode": "GIG",
+                                "terminal": "2",
+                                "at": "2020-08-01T21:50:00"
+                            },
+                            "arrival": {
+                                "iataCode": "LHR",
+                                "terminal": "5",
+                                "at": "2020-08-02T13:10:00"
+                            },
+                            "carrierCode": "BA",
+                            "number": "248",
+                            "aircraft": {
+                                "code": "788"
+                            },
+                            "operating": {
+                                "carrierCode": "BA"
+                            },
+                            "duration": "PT11H20M",
+                            "id": "1",
+                            "numberOfStops": 0,
+                            "blacklistedInEU": false
+                        },
+                        {
+                            "departure": {
+                                "iataCode": "LHR",
+                                "terminal": "5",
+                                "at": "2020-08-02T15:15:00"
+                            },
+                            "arrival": {
+                                "iataCode": "MAD",
+                                "terminal": "4S",
+                                "at": "2020-08-02T18:45:00"
+                            },
+                            "carrierCode": "BA",
+                            "number": "462",
+                            "aircraft": {
+                                "code": "321"
+                            },
+                            "operating": {
+                                "carrierCode": "BA"
+                            },
+                            "duration": "PT2H30M",
+                            "id": "2",
+                            "numberOfStops": 0,
+                            "blacklistedInEU": false
+                        }
+                    ]
+                },
+                {
+                    "duration": "PT13H35M",
+                    "segments": [
+                        {
+                            "departure": {
+                                "iataCode": "MAD",
+                                "terminal": "4S",
+                                "at": "2020-08-05T23:55:00"
+                            },
+                            "arrival": {
+                                "iataCode": "GRU",
+                                "terminal": "3",
+                                "at": "2020-08-06T05:40:00"
+                            },
+                            "carrierCode": "IB",
+                            "number": "6827",
+                            "aircraft": {
+                                "code": "346"
+                            },
+                            "operating": {
+                                "carrierCode": "IB"
+                            },
+                            "duration": "PT10H45M",
+                            "id": "5",
+                            "numberOfStops": 0,
+                            "blacklistedInEU": false
+                        },
+                        {
+                            "departure": {
+                                "iataCode": "GRU",
+                                "terminal": "2",
+                                "at": "2020-08-06T07:30:00"
+                            },
+                            "arrival": {
+                                "iataCode": "GIG",
+                                "terminal": "2",
+                                "at": "2020-08-06T08:30:00"
+                            },
+                            "carrierCode": "LA",
+                            "number": "4508",
+                            "aircraft": {
+                                "code": "320"
+                            },
+                            "duration": "PT1H",
+                            "id": "6",
+                            "numberOfStops": 0,
+                            "blacklistedInEU": false
+                        }
+                    ]
+                }
+            ],
+            "price": {
+                "currency": "USD",
+                "total": "3842.10",
+                "base": "3661.00",
+                "fees": [
+                    {
+                        "amount": "0.00",
+                        "type": "SUPPLIER"
+                    },
+                    {
+                        "amount": "0.00",
+                        "type": "TICKETING"
+                    }
+                ],
+                "grandTotal": "3842.10"
+            },
+            "pricingOptions": {
+                "fareType": [
+                    "PUBLISHED"
+                ],
+                "includedCheckedBagsOnly": false
+            },
+            "validatingAirlineCodes": [
+                "BA"
+            ],
+            "travelerPricings": [
+                {
+                    "travelerId": "1",
+                    "fareOption": "STANDARD",
+                    "travelerType": "ADULT",
+                    "price": {
+                        "currency": "USD",
+                        "total": "2178.55",
+                        "base": "2088.00"
+                    },
+                    "fareDetailsBySegment": [
+                        {
+                            "segmentId": "1",
+                            "cabin": "BUSINESS",
+                            "fareBasis": "RNNZ60S3",
+                            "brandedFare": "BUSINESS",
+                            "class": "R",
+                            "includedCheckedBags": {
+                                "quantity": 2
+                            }
+                        },
+                        {
+                            "segmentId": "2",
+                            "cabin": "BUSINESS",
+                            "fareBasis": "RNNZ60S3",
+                            "brandedFare": "BUSINESS",
+                            "class": "J",
+                            "includedCheckedBags": {
+                                "quantity": 2
+                            }
+                        },
+                        {
+                            "segmentId": "5",
+                            "cabin": "ECONOMY",
+                            "fareBasis": "VDH0NNM3",
+                            "brandedFare": "BAGSEAT",
+                            "class": "V",
+                            "includedCheckedBags": {
+                                "quantity": 1
+                            }
+                        },
+                        {
+                            "segmentId": "6",
+                            "cabin": "ECONOMY",
+                            "fareBasis": "VDH0NNM3",
+                            "brandedFare": "BAGSEAT",
+                            "class": "V",
+                            "includedCheckedBags": {
+                                "quantity": 1
+                            }
+                        }
+                    ]
+                },
+                {
+                    "travelerId": "2",
+                    "fareOption": "STANDARD",
+                    "travelerType": "CHILD",
+                    "price": {
+                        "currency": "USD",
+                        "total": "1663.55",
+                        "base": "1573.00"
+                    },
+                    "fareDetailsBySegment": [
+                        {
+                            "segmentId": "1",
+                            "cabin": "BUSINESS",
+                            "fareBasis": "RNNZ60S3",
+                            "brandedFare": "BUSINESS",
+                            "class": "R"
+                        },
+                        {
+                            "segmentId": "2",
+                            "cabin": "BUSINESS",
+                            "fareBasis": "RNNZ60S3",
+                            "brandedFare": "BUSINESS",
+                            "class": "J"
+                        },
+                        {
+                            "segmentId": "5",
+                            "cabin": "ECONOMY",
+                            "fareBasis": "VDH0NNM3",
+                            "brandedFare": "BAGSEAT",
+                            "class": "V"
+                        },
+                        {
+                            "segmentId": "6",
+                            "cabin": "ECONOMY",
+                            "fareBasis": "VDH0NNM3",
+                            "brandedFare": "BAGSEAT",
+                            "class": "V"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "flight-offer",
+            "id": "2",
+            "source": "GDS",
+            "instantTicketingRequired": false,
+            "nonHomogeneous": false,
+            "oneWay": false,
+            "lastTicketingDate": "2020-01-16",
+            "numberOfBookableSeats": 7,
+            "itineraries": [
+                {
+                    "duration": "PT15H55M",
+                    "segments": [
+                        {
+                            "departure": {
+                                "iataCode": "GIG",
+                                "terminal": "2",
+                                "at": "2020-08-01T21:50:00"
+                            },
+                            "arrival": {
+                                "iataCode": "LHR",
+                                "terminal": "5",
+                                "at": "2020-08-02T13:10:00"
+                            },
+                            "carrierCode": "BA",
+                            "number": "248",
+                            "aircraft": {
+                                "code": "788"
+                            },
+                            "operating": {
+                                "carrierCode": "BA"
+                            },
+                            "duration": "PT11H20M",
+                            "id": "1",
+                            "numberOfStops": 0,
+                            "blacklistedInEU": false
+                        },
+                        {
+                            "departure": {
+                                "iataCode": "LHR",
+                                "terminal": "5",
+                                "at": "2020-08-02T15:15:00"
+                            },
+                            "arrival": {
+                                "iataCode": "MAD",
+                                "terminal": "4S",
+                                "at": "2020-08-02T18:45:00"
+                            },
+                            "carrierCode": "BA",
+                            "number": "462",
+                            "aircraft": {
+                                "code": "321"
+                            },
+                            "operating": {
+                                "carrierCode": "BA"
+                            },
+                            "duration": "PT2H30M",
+                            "id": "2",
+                            "numberOfStops": 0,
+                            "blacklistedInEU": false
+                        }
+                    ]
+                },
+                {
+                    "duration": "PT19H5M",
+                    "segments": [
+                        {
+                            "departure": {
+                                "iataCode": "MAD",
+                                "terminal": "4S",
+                                "at": "2020-08-05T23:55:00"
+                            },
+                            "arrival": {
+                                "iataCode": "GRU",
+                                "terminal": "3",
+                                "at": "2020-08-06T05:40:00"
+                            },
+                            "carrierCode": "IB",
+                            "number": "6827",
+                            "aircraft": {
+                                "code": "346"
+                            },
+                            "operating": {
+                                "carrierCode": "IB"
+                            },
+                            "duration": "PT10H45M",
+                            "id": "3",
+                            "numberOfStops": 0,
+                            "blacklistedInEU": false
+                        },
+                        {
+                            "departure": {
+                                "iataCode": "GRU",
+                                "terminal": "2",
+                                "at": "2020-08-06T13:00:00"
+                            },
+                            "arrival": {
+                                "iataCode": "GIG",
+                                "terminal": "2",
+                                "at": "2020-08-06T14:00:00"
+                            },
+                            "carrierCode": "LA",
+                            "number": "4537",
+                            "aircraft": {
+                                "code": "321"
+                            },
+                            "duration": "PT1H",
+                            "id": "4",
+                            "numberOfStops": 0,
+                            "blacklistedInEU": false
+                        }
+                    ]
+                }
+            ],
+            "price": {
+                "currency": "USD",
+                "total": "3842.10",
+                "base": "3661.00",
+                "fees": [
+                    {
+                        "amount": "0.00",
+                        "type": "SUPPLIER"
+                    },
+                    {
+                        "amount": "0.00",
+                        "type": "TICKETING"
+                    }
+                ],
+                "grandTotal": "3842.10"
+            },
+            "pricingOptions": {
+                "fareType": [
+                    "PUBLISHED"
+                ],
+                "includedCheckedBagsOnly": false
+            },
+            "validatingAirlineCodes": [
+                "BA"
+            ],
+            "travelerPricings": [
+                {
+                    "travelerId": "1",
+                    "fareOption": "STANDARD",
+                    "travelerType": "ADULT",
+                    "price": {
+                        "currency": "USD",
+                        "total": "2178.55",
+                        "base": "2088.00"
+                    },
+                    "fareDetailsBySegment": [
+                        {
+                            "segmentId": "1",
+                            "cabin": "BUSINESS",
+                            "fareBasis": "RNNZ60S3",
+                            "brandedFare": "BUSINESS",
+                            "class": "R",
+                            "includedCheckedBags": {
+                                "quantity": 2
+                            }
+                        },
+                        {
+                            "segmentId": "2",
+                            "cabin": "BUSINESS",
+                            "fareBasis": "RNNZ60S3",
+                            "brandedFare": "BUSINESS",
+                            "class": "J",
+                            "includedCheckedBags": {
+                                "quantity": 2
+                            }
+                        },
+                        {
+                            "segmentId": "3",
+                            "cabin": "ECONOMY",
+                            "fareBasis": "VDH0NNM3",
+                            "brandedFare": "BAGSEAT",
+                            "class": "V",
+                            "includedCheckedBags": {
+                                "quantity": 1
+                            }
+                        },
+                        {
+                            "segmentId": "4",
+                            "cabin": "ECONOMY",
+                            "fareBasis": "VDH0NNM3",
+                            "brandedFare": "BAGSEAT",
+                            "class": "V",
+                            "includedCheckedBags": {
+                                "quantity": 1
+                            }
+                        }
+                    ]
+                },
+                {
+                    "travelerId": "2",
+                    "fareOption": "STANDARD",
+                    "travelerType": "CHILD",
+                    "price": {
+                        "currency": "USD",
+                        "total": "1663.55",
+                        "base": "1573.00"
+                    },
+                    "fareDetailsBySegment": [
+                        {
+                            "segmentId": "1",
+                            "cabin": "BUSINESS",
+                            "fareBasis": "RNNZ60S3",
+                            "brandedFare": "BUSINESS",
+                            "class": "R"
+                        },
+                        {
+                            "segmentId": "2",
+                            "cabin": "BUSINESS",
+                            "fareBasis": "RNNZ60S3",
+                            "brandedFare": "BUSINESS",
+                            "class": "J"
+                        },
+                        {
+                            "segmentId": "3",
+                            "cabin": "ECONOMY",
+                            "fareBasis": "VDH0NNM3",
+                            "brandedFare": "BAGSEAT",
+                            "class": "V"
+                        },
+                        {
+                            "segmentId": "4",
+                            "cabin": "ECONOMY",
+                            "fareBasis": "VDH0NNM3",
+                            "brandedFare": "BAGSEAT",
+                            "class": "V"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/tests/resources/__files/flight_choice_prediction_post_response_ok.json
+++ b/tests/resources/__files/flight_choice_prediction_post_response_ok.json
@@ -1,0 +1,509 @@
+{
+  "data": [
+    {
+      "choiceProbability": "0.5000000000000000",
+      "id": "1",
+      "instantTicketingRequired": false,
+      "itineraries": [
+        {
+          "duration": "PT15H55M",
+          "segments": [
+            {
+              "blacklistedInEU": false,
+              "id": "1",
+              "numberOfStops": 0,
+              "aircraft": {
+                "code": "788"
+              },
+              "arrival": {
+                "iataCode": "LHR",
+                "terminal": "5",
+                "at": "2020-08-02T13:10:00"
+              },
+              "carrierCode": "BA",
+              "departure": {
+                "iataCode": "GIG",
+                "terminal": "2",
+                "at": "2020-08-01T21:50:00"
+              },
+              "duration": "PT11H20M",
+              "number": "248",
+              "operating": {
+                "carrierCode": "BA"
+              }
+            },
+            {
+              "blacklistedInEU": false,
+              "id": "2",
+              "numberOfStops": 0,
+              "aircraft": {
+                "code": "321"
+              },
+              "arrival": {
+                "iataCode": "MAD",
+                "terminal": "4S",
+                "at": "2020-08-02T18:45:00"
+              },
+              "carrierCode": "BA",
+              "departure": {
+                "iataCode": "LHR",
+                "terminal": "5",
+                "at": "2020-08-02T15:15:00"
+              },
+              "duration": "PT2H30M",
+              "number": "462",
+              "operating": {
+                "carrierCode": "BA"
+              }
+            }
+          ]
+        },
+        {
+          "duration": "PT13H35M",
+          "segments": [
+            {
+              "blacklistedInEU": false,
+              "id": "5",
+              "numberOfStops": 0,
+              "aircraft": {
+                "code": "346"
+              },
+              "arrival": {
+                "iataCode": "GRU",
+                "terminal": "3",
+                "at": "2020-08-06T05:40:00"
+              },
+              "carrierCode": "IB",
+              "departure": {
+                "iataCode": "MAD",
+                "terminal": "4S",
+                "at": "2020-08-05T23:55:00"
+              },
+              "duration": "PT10H45M",
+              "number": "6827",
+              "operating": {
+                "carrierCode": "IB"
+              }
+            },
+            {
+              "blacklistedInEU": false,
+              "id": "6",
+              "numberOfStops": 0,
+              "aircraft": {
+                "code": "320"
+              },
+              "arrival": {
+                "iataCode": "GIG",
+                "terminal": "2",
+                "at": "2020-08-06T08:30:00"
+              },
+              "carrierCode": "LA",
+              "departure": {
+                "iataCode": "GRU",
+                "terminal": "2",
+                "at": "2020-08-06T07:30:00"
+              },
+              "duration": "PT1H",
+              "number": "4508"
+            }
+          ]
+        }
+      ],
+      "lastTicketingDate": "2020-01-16",
+      "nonHomogeneous": false,
+      "numberOfBookableSeats": 7,
+      "oneWay": false,
+      "price": {
+        "grandTotal": "3842.10",
+        "base": "3661.00",
+        "currency": "USD",
+        "fees": [
+          {
+            "amount": "0.00",
+            "type": "SUPPLIER"
+          },
+          {
+            "amount": "0.00",
+            "type": "TICKETING"
+          }
+        ],
+        "total": "3842.10"
+      },
+      "pricingOptions": {
+        "fareType": [
+          "PUBLISHED"
+        ]
+      },
+      "source": "GDS",
+      "travelerPricings": [
+        {
+          "fareDetailsBySegment": [
+            {
+              "brandedFare": "BUSINESS",
+              "cabin": "BUSINESS",
+              "class": "R",
+              "fareBasis": "RNNZ60S3",
+              "includedCheckedBags": {
+                "quantity": 2
+              },
+              "segmentId": "1"
+            },
+            {
+              "brandedFare": "BUSINESS",
+              "cabin": "BUSINESS",
+              "class": "J",
+              "fareBasis": "RNNZ60S3",
+              "includedCheckedBags": {
+                "quantity": 2
+              },
+              "segmentId": "2"
+            },
+            {
+              "brandedFare": "BAGSEAT",
+              "cabin": "ECONOMY",
+              "class": "V",
+              "fareBasis": "VDH0NNM3",
+              "includedCheckedBags": {
+                "quantity": 1
+              },
+              "segmentId": "5"
+            },
+            {
+              "brandedFare": "BAGSEAT",
+              "cabin": "ECONOMY",
+              "class": "V",
+              "fareBasis": "VDH0NNM3",
+              "includedCheckedBags": {
+                "quantity": 1
+              },
+              "segmentId": "6"
+            }
+          ],
+          "fareOption": "STANDARD",
+          "price": {
+            "base": "2088.00",
+            "currency": "USD",
+            "total": "2178.55"
+          },
+          "travelerId": "1",
+          "travelerType": "ADULT"
+        },
+        {
+          "fareDetailsBySegment": [
+            {
+              "brandedFare": "BUSINESS",
+              "cabin": "BUSINESS",
+              "class": "R",
+              "fareBasis": "RNNZ60S3",
+              "segmentId": "1"
+            },
+            {
+              "brandedFare": "BUSINESS",
+              "cabin": "BUSINESS",
+              "class": "J",
+              "fareBasis": "RNNZ60S3",
+              "segmentId": "2"
+            },
+            {
+              "brandedFare": "BAGSEAT",
+              "cabin": "ECONOMY",
+              "class": "V",
+              "fareBasis": "VDH0NNM3",
+              "segmentId": "5"
+            },
+            {
+              "brandedFare": "BAGSEAT",
+              "cabin": "ECONOMY",
+              "class": "V",
+              "fareBasis": "VDH0NNM3",
+              "segmentId": "6"
+            }
+          ],
+          "fareOption": "STANDARD",
+          "price": {
+            "base": "1573.00",
+            "currency": "USD",
+            "total": "1663.55"
+          },
+          "travelerId": "2",
+          "travelerType": "CHILD"
+        }
+      ],
+      "type": "flight-offer",
+      "validatingAirlineCodes": [
+        "BA"
+      ]
+    },
+    {
+      "choiceProbability": "0.5000000000000000",
+      "id": "2",
+      "instantTicketingRequired": false,
+      "itineraries": [
+        {
+          "duration": "PT15H55M",
+          "segments": [
+            {
+              "blacklistedInEU": false,
+              "id": "1",
+              "numberOfStops": 0,
+              "aircraft": {
+                "code": "788"
+              },
+              "arrival": {
+                "iataCode": "LHR",
+                "terminal": "5",
+                "at": "2020-08-02T13:10:00"
+              },
+              "carrierCode": "BA",
+              "departure": {
+                "iataCode": "GIG",
+                "terminal": "2",
+                "at": "2020-08-01T21:50:00"
+              },
+              "duration": "PT11H20M",
+              "number": "248",
+              "operating": {
+                "carrierCode": "BA"
+              }
+            },
+            {
+              "blacklistedInEU": false,
+              "id": "2",
+              "numberOfStops": 0,
+              "aircraft": {
+                "code": "321"
+              },
+              "arrival": {
+                "iataCode": "MAD",
+                "terminal": "4S",
+                "at": "2020-08-02T18:45:00"
+              },
+              "carrierCode": "BA",
+              "departure": {
+                "iataCode": "LHR",
+                "terminal": "5",
+                "at": "2020-08-02T15:15:00"
+              },
+              "duration": "PT2H30M",
+              "number": "462",
+              "operating": {
+                "carrierCode": "BA"
+              }
+            }
+          ]
+        },
+        {
+          "duration": "PT19H5M",
+          "segments": [
+            {
+              "blacklistedInEU": false,
+              "id": "3",
+              "numberOfStops": 0,
+              "aircraft": {
+                "code": "346"
+              },
+              "arrival": {
+                "iataCode": "GRU",
+                "terminal": "3",
+                "at": "2020-08-06T05:40:00"
+              },
+              "carrierCode": "IB",
+              "departure": {
+                "iataCode": "MAD",
+                "terminal": "4S",
+                "at": "2020-08-05T23:55:00"
+              },
+              "duration": "PT10H45M",
+              "number": "6827",
+              "operating": {
+                "carrierCode": "IB"
+              }
+            },
+            {
+              "blacklistedInEU": false,
+              "id": "4",
+              "numberOfStops": 0,
+              "aircraft": {
+                "code": "321"
+              },
+              "arrival": {
+                "iataCode": "GIG",
+                "terminal": "2",
+                "at": "2020-08-06T14:00:00"
+              },
+              "carrierCode": "LA",
+              "departure": {
+                "iataCode": "GRU",
+                "terminal": "2",
+                "at": "2020-08-06T13:00:00"
+              },
+              "duration": "PT1H",
+              "number": "4537"
+            }
+          ]
+        }
+      ],
+      "lastTicketingDate": "2020-01-16",
+      "nonHomogeneous": false,
+      "numberOfBookableSeats": 7,
+      "oneWay": false,
+      "price": {
+        "grandTotal": "3842.10",
+        "base": "3661.00",
+        "currency": "USD",
+        "fees": [
+          {
+            "amount": "0.00",
+            "type": "SUPPLIER"
+          },
+          {
+            "amount": "0.00",
+            "type": "TICKETING"
+          }
+        ],
+        "total": "3842.10"
+      },
+      "pricingOptions": {
+        "fareType": [
+          "PUBLISHED"
+        ]
+      },
+      "source": "GDS",
+      "travelerPricings": [
+        {
+          "fareDetailsBySegment": [
+            {
+              "brandedFare": "BUSINESS",
+              "cabin": "BUSINESS",
+              "class": "R",
+              "fareBasis": "RNNZ60S3",
+              "includedCheckedBags": {
+                "quantity": 2
+              },
+              "segmentId": "1"
+            },
+            {
+              "brandedFare": "BUSINESS",
+              "cabin": "BUSINESS",
+              "class": "J",
+              "fareBasis": "RNNZ60S3",
+              "includedCheckedBags": {
+                "quantity": 2
+              },
+              "segmentId": "2"
+            },
+            {
+              "brandedFare": "BAGSEAT",
+              "cabin": "ECONOMY",
+              "class": "V",
+              "fareBasis": "VDH0NNM3",
+              "includedCheckedBags": {
+                "quantity": 1
+              },
+              "segmentId": "3"
+            },
+            {
+              "brandedFare": "BAGSEAT",
+              "cabin": "ECONOMY",
+              "class": "V",
+              "fareBasis": "VDH0NNM3",
+              "includedCheckedBags": {
+                "quantity": 1
+              },
+              "segmentId": "4"
+            }
+          ],
+          "fareOption": "STANDARD",
+          "price": {
+            "base": "2088.00",
+            "currency": "USD",
+            "total": "2178.55"
+          },
+          "travelerId": "1",
+          "travelerType": "ADULT"
+        },
+        {
+          "fareDetailsBySegment": [
+            {
+              "brandedFare": "BUSINESS",
+              "cabin": "BUSINESS",
+              "class": "R",
+              "fareBasis": "RNNZ60S3",
+              "segmentId": "1"
+            },
+            {
+              "brandedFare": "BUSINESS",
+              "cabin": "BUSINESS",
+              "class": "J",
+              "fareBasis": "RNNZ60S3",
+              "segmentId": "2"
+            },
+            {
+              "brandedFare": "BAGSEAT",
+              "cabin": "ECONOMY",
+              "class": "V",
+              "fareBasis": "VDH0NNM3",
+              "segmentId": "3"
+            },
+            {
+              "brandedFare": "BAGSEAT",
+              "cabin": "ECONOMY",
+              "class": "V",
+              "fareBasis": "VDH0NNM3",
+              "segmentId": "4"
+            }
+          ],
+          "fareOption": "STANDARD",
+          "price": {
+            "base": "1573.00",
+            "currency": "USD",
+            "total": "1663.55"
+          },
+          "travelerId": "2",
+          "travelerType": "CHILD"
+        }
+      ],
+      "type": "flight-offer",
+      "validatingAirlineCodes": [
+        "BA"
+      ]
+    }
+  ],
+  "dictionaries": {
+    "aircraft": {
+      "320": "AIRBUS INDUSTRIE A320-100/200",
+      "321": "AIRBUS INDUSTRIE A321",
+      "346": "AIRBUS INDUSTRIE A340-600",
+      "788": "BOEING 787-8"
+    },
+    "carriers": {
+      "BA": "BRITISH AIRWAYS",
+      "IB": "IBERIA",
+      "LA": "LATAM AIRLINES GROUP"
+    },
+    "currencies": {
+      "USD": "US DOLLAR"
+    },
+    "locations": {
+      "GIG": {
+        "cityCode": "RIO",
+        "countryCode": "BR"
+      },
+      "GRU": {
+        "cityCode": "SAO",
+        "countryCode": "BR"
+      },
+      "LHR": {
+        "cityCode": "LON",
+        "countryCode": "GB"
+      },
+      "MAD": {
+        "cityCode": "MAD",
+        "countryCode": "ES"
+      }
+    }
+  },
+  "meta": {
+    "count": 2
+  }
+}

--- a/tests/shopping/FlightOffersTest.php
+++ b/tests/shopping/FlightOffersTest.php
@@ -24,6 +24,7 @@ use PHPUnit\Framework\TestCase;
  * This test covers the endpoint and its related returned resources.
  * @covers \Amadeus\Shopping\FlightOffers
  * @covers \Amadeus\Shopping\FlightOffers\Pricing
+ * @covers \Amadeus\Shopping\FlightOffers\Prediction
  *
  * @covers \Amadeus\Resources\Resource
  * @covers \Amadeus\Resources\FlightOffer

--- a/tests/shopping/flightOffers/PredictionTest.php
+++ b/tests/shopping/flightOffers/PredictionTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Amadeus\Tests\Shopping\FlightOffers;
+
+use Amadeus\Amadeus;
+use Amadeus\Client\HTTPClient;
+use Amadeus\Client\Response;
+use Amadeus\Exceptions\ResponseException;
+use Amadeus\Resources\FareRules;
+use Amadeus\Resources\FlightOffer;
+use Amadeus\Resources\Resource;
+use Amadeus\Shopping\FlightOffers\Prediction;
+use Amadeus\Tests\PHPUnitUtil;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * This test covers the endpoint and its related returned resources.
+ * @covers \Amadeus\Shopping\FlightOffers\Prediction
+ *
+ * @covers \Amadeus\Resources\Resource
+ * @covers \Amadeus\Resources\FlightOffer
+ * @see https://developers.amadeus.com/self-service/category/air/api-doc/flight-choice-prediction/api-reference
+ */
+final class PredictionTest extends TestCase
+{
+    private Amadeus $amadeus;
+    private HTTPClient $client;
+
+    /**
+     * @Before
+     */
+    public function setUp(): void
+    {
+        // Mock an Amadeus with HTTPClient
+        $this->amadeus = $this->createMock(Amadeus::class);
+        $this->client = $this->createMock(HTTPClient::class);
+        $this->amadeus->expects($this->any())
+            ->method("getClient")
+            ->willReturn($this->client);
+    }
+
+    /**
+     * @throws ResponseException
+     */
+    public function test_given_client_when_call_flight_choice_prediction_then_ok(): void
+    {
+        // Prepare Response
+        $fileContent = PHPUnitUtil::readFile(
+            PHPUnitUtil::RESOURCE_PATH_ROOT . "flight_choice_prediction_post_response_ok.json"
+        );
+        $data = json_decode($fileContent)->{'data'};
+        $response = $this->createMock(Response::class);
+        $response->expects($this->any())
+            ->method("getData")
+            ->willReturn($data);
+
+        // Given
+        $body = PHPUnitUtil::readFile(
+            PHPUnitUtil::RESOURCE_PATH_ROOT . "flight_choice_prediction_post_request_ok.json"
+        );
+        $flightOffersArray = Resource::toResourceArray(
+            json_decode($body)->{'data'},
+            FlightOffer::class
+        );
+        /* @phpstan-ignore-next-line */
+        $this->client->expects($this->any())
+            ->method("postWithStringBody")
+            ->with("/v2/shopping/flight-offers/prediction", $body)
+            ->willReturn($response);
+
+        // When
+        $prediction = new Prediction($this->amadeus);
+        $predictionResult1 = $prediction->post($body);
+        $predictionResult2 = $prediction->postWithFlightOffers($flightOffersArray);
+
+        // Then
+        $this->assertNotNull($predictionResult1);
+        $this->assertNotNull($predictionResult2);
+
+        // Resource
+        // FlightOffer
+        // See FlightOffersTest.php
+        $flightOffer = $predictionResult1[0];
+        $this->assertEquals("0.5000000000000000", $flightOffer->getChoiceProbability());
+    }
+}


### PR DESCRIPTION
Fixes #39 

- [x] Resource Model - ```src/resources/FlightOffer.php``` (Same name resource existed before, thus just need to add some properties for creating the union)
- [x] Namespace Client and API support 

   - [x]  ```$amadeus->getShopping()->getFlightOffers()->getPrediction()->post($body);```
   - [x]  ```$amadeus->getShopping()->getFlightOffers()->getPrediction()->postWithFlightOffers($flightOffers)```;

- [x] Namespace Test - ```NamespaceTest.php```
- [x] Endpoint and Resource Test - ```tests/shopping/flightOffers/PredictionTest.php```

BTW,
- [x] Update the list for APIs need HTTP override