### PR TITLE
fix wrong description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Similarly, to select a resource by ID, you can pass in the ID to the **singular*
 For example,  `GET /v2/shopping/hotel-offers/XXX` would be:
 
 ```PHP
-$amadeus->getShopping()->getHotelOffer()->get("XXX");
+$amadeus->getShopping()->getHotelOffer("XXX")->get();
 ```
 
 Additionally, You can make any arbitrary API call as well directly with the methods provided below:


### PR DESCRIPTION
change 
``` PHP 
$amadeus->getShopping()->getHotelOffer()->get("XXX");
```
to
```PHP
$amadeus->getShopping()->getHotelOffer("XXX")->get();
```