### PR TITLE
remove redundant NULL type assignment to endpoint variables

### DIFF
--- a/src/Airport.php
+++ b/src/Airport.php
@@ -29,7 +29,7 @@ class Airport
      *   <code>/v1/airport/direct-destinations</code> endpoints.
      * </p>
      */
-    private ?DirectDestinations $directDestinations;
+    private DirectDestinations $directDestinations;
 
     /**
      * @param Amadeus $amadeus
@@ -44,9 +44,9 @@ class Airport
      *   Get a namespaced client for the
      *   <code>/v1/airport/direct-destinations</code> endpoints.
      * </p>
-     * @return DirectDestinations|null
+     * @return DirectDestinations
      */
-    public function getDirectDestinations(): ?DirectDestinations
+    public function getDirectDestinations(): DirectDestinations
     {
         return $this->directDestinations;
     }

--- a/src/Booking.php
+++ b/src/Booking.php
@@ -30,7 +30,7 @@ class Booking
      *   <code>/v1/booking/flightOrders</code> endpoints.
      * </p>
      */
-    private ?FlightOrders  $flightOrders;
+    private FlightOrders  $flightOrders;
 
     /**
      * <p>
@@ -38,7 +38,7 @@ class Booking
      *   <code>/v1/booking/hotelBookings</code> endpoints.
      * </p>
      */
-    private ?HotelBookings $hotelBookings;
+    private HotelBookings $hotelBookings;
 
     /**
      * @param Amadeus $amadeus
@@ -54,9 +54,9 @@ class Booking
      *   Get a namespaced client for the
      *   <code>/v1/booking/flightOrders</code> endpoints.
      * </p>
-     * @return FlightOrders|null
+     * @return FlightOrders
      */
-    public function getFlightOrders(): ?FlightOrders
+    public function getFlightOrders(): FlightOrders
     {
         return $this->flightOrders;
     }
@@ -66,9 +66,9 @@ class Booking
      *   Get a namespaced client for the
      *   <code>/v1/booking/hotelBookings</code> endpoints.
      * </p>
-     * @return HotelBookings|null
+     * @return HotelBookings
      */
-    public function getHotelBookings(): ?HotelBookings
+    public function getHotelBookings(): HotelBookings
     {
         return $this->hotelBookings;
     }

--- a/src/ReferenceData.php
+++ b/src/ReferenceData.php
@@ -33,7 +33,7 @@ class ReferenceData
      *   <code>/v1/reference-data/locations</code> endpoints.
      * </p>
      */
-    private ?Locations $locations;
+    private Locations $locations;
 
     /**
      * <p>
@@ -41,7 +41,7 @@ class ReferenceData
      *   <code>/v1/reference-data/airlines</code> endpoints.
      * </p>
      */
-    private ?Airlines $airlines;
+    private Airlines $airlines;
 
     /**
      * @param Amadeus $amadeus
@@ -58,9 +58,9 @@ class ReferenceData
      *   Get a namespaced client for the
      *   <code>/v1/reference-data/locations</code> endpoints.
      * </p>
-     * @return Locations|null
+     * @return Locations
      */
-    public function getLocations(): ?Locations
+    public function getLocations(): Locations
     {
         return $this->locations;
     }
@@ -72,9 +72,9 @@ class ReferenceData
      *   <code>/v1/reference-data/locations/:location_id</code> endpoints.
      * </p>
      * @param string $locationId
-     * @return Location|null
+     * @return Location
      */
-    public function getLocation(string $locationId): ?Location
+    public function getLocation(string $locationId): Location
     {
         return new Location($this->amadeus, $locationId);
     }
@@ -84,9 +84,9 @@ class ReferenceData
      *   Get a namespaced client for the
      *   <code>/v1/reference-data/airlines</code> endpoints.
      * </p>
-     * @return Airlines|null
+     * @return Airlines
      */
-    public function getAirlines(): ?Airlines
+    public function getAirlines(): Airlines
     {
         return $this->airlines;
     }

--- a/src/Schedule.php
+++ b/src/Schedule.php
@@ -29,7 +29,7 @@ class Schedule
      *   <code>/v2/schedule/flights</code> endpoints.
      * </p>
      */
-    private ?Flights $flights;
+    private Flights $flights;
 
     /**
      * @param Amadeus $amadeus
@@ -44,9 +44,9 @@ class Schedule
      *   Get a namespaced client for the
      *   <code>/v2/schedule/flights</code> endpoints.
      * </p>
-     * @return Flights|null
+     * @return Flights
      */
-    public function getFlights(): ?Flights
+    public function getFlights(): Flights
     {
         return $this->flights;
     }

--- a/src/Shopping.php
+++ b/src/Shopping.php
@@ -38,7 +38,7 @@ class Shopping
      *   <code>/v1/shopping/availability</code> endpoints.
      * </p>
      */
-    private ?Availability $availability;
+    private Availability $availability;
 
     /**
      * <p>
@@ -46,7 +46,7 @@ class Shopping
      *   <code>/v2/shopping/flight-offers</code> endpoints.
      * </p>
      */
-    private ?FlightOffers $flightOffers;
+    private FlightOffers $flightOffers;
 
     /**
      * <p>
@@ -54,7 +54,7 @@ class Shopping
      *   <code>/v3/shopping/hotel-offers</code> endpoints.
      * </p>
      */
-    private ?HotelOffers $hotelOffers;
+    private HotelOffers $hotelOffers;
 
     /**
      * <p>
@@ -62,7 +62,7 @@ class Shopping
      *   <code>/v1/shopping/flight-dates</code> endpoints.
      * </p>
      */
-    private ?FlightDates $flightDates;
+    private FlightDates $flightDates;
 
     /**
      * <p>
@@ -70,7 +70,7 @@ class Shopping
      *   <code>/v1/shopping/flight-destinations</code> endpoints.
      * </p>
      */
-    private ?FlightDestinations $flightDestinations;
+    private FlightDestinations $flightDestinations;
 
     /**
      * <p>
@@ -78,7 +78,7 @@ class Shopping
      *   <code>/v1/shopping/activities</code> endpoints.
      * </p>
      */
-    private ?Activities $activities;
+    private Activities $activities;
 
     /**
      * @param Amadeus $amadeus
@@ -99,9 +99,9 @@ class Shopping
      *   Get a namespaced client for the
      *   <code>/v1/shopping/availability</code> endpoints.
      * </p>
-     * @return Availability|null
+     * @return Availability
      */
-    public function getAvailability(): ?Availability
+    public function getAvailability(): Availability
     {
         return $this->availability;
     }
@@ -111,9 +111,9 @@ class Shopping
      *   Get a namespaced client for the
      *   <code>/v2/shopping/flight-offers</code> endpoints.
      * </p>
-     * @return FlightOffers|null
+     * @return FlightOffers
      */
-    public function getFlightOffers(): ?FlightOffers
+    public function getFlightOffers(): FlightOffers
     {
         return $this->flightOffers;
     }
@@ -124,9 +124,9 @@ class Shopping
      *   <code>/v3/shopping/hotel-offers/:offer_id</code> endpoints.
      * </p>
      * @param string $offerId
-     * @return HotelOffer|null
+     * @return HotelOffer
      */
-    public function getHotelOffer(string $offerId): ?HotelOffer
+    public function getHotelOffer(string $offerId): HotelOffer
     {
         return new HotelOffer($this->amadeus, $offerId);
     }
@@ -136,9 +136,9 @@ class Shopping
      *   Get a namespaced client for the
      *   <code>/v3/shopping/hotel-offers</code> endpoints.
      * </p>
-     * @return HotelOffers|null
+     * @return HotelOffers
      */
-    public function getHotelOffers(): ?HotelOffers
+    public function getHotelOffers(): HotelOffers
     {
         return $this->hotelOffers;
     }
@@ -148,9 +148,9 @@ class Shopping
      *   Get a namespaced client for the
      *   <code>/v1/shopping/flight-dates</code> endpoints.
      * </p>
-     * @return FlightDates|null
+     * @return FlightDates
      */
-    public function getFlightDates(): ?FlightDates
+    public function getFlightDates(): FlightDates
     {
         return $this->flightDates;
     }
@@ -160,9 +160,9 @@ class Shopping
      *   Get a namespaced client for the
      *   <code>/v1/shopping/flight-destinations</code> endpoints.
      * </p>
-     * @return FlightDestinations|null
+     * @return FlightDestinations
      */
-    public function getFlightDestinations(): ?FlightDestinations
+    public function getFlightDestinations(): FlightDestinations
     {
         return $this->flightDestinations;
     }
@@ -172,9 +172,9 @@ class Shopping
      *   Get a namespaced client for the
      *   <code>/v1/shopping/activities</code> endpoints.
      * </p>
-     * @return Activities|null
+     * @return Activities
      */
-    public function getActivities(): ?Activities
+    public function getActivities(): Activities
     {
         return $this->activities;
     }
@@ -185,9 +185,9 @@ class Shopping
      *   <code>/v1/shopping/activities/:activity_id</code> endpoints.
      * </p>
      * @param string $activityId
-     * @return Activity|null
+     * @return Activity
      */
-    public function getActivity(string $activityId): ?Activity
+    public function getActivity(string $activityId): Activity
     {
         return new Activity($this->amadeus, $activityId);
     }

--- a/src/Travel.php
+++ b/src/Travel.php
@@ -29,7 +29,7 @@ class Travel
      *   <code>/v1/travel/predictions</code> endpoints.
      * </p>
      */
-    private ?Predictions $predictions;
+    private Predictions $predictions;
 
     /**
      * @param Amadeus $amadeus
@@ -44,9 +44,9 @@ class Travel
      *   Get a namespaced client for the
      *   <code>/v1/travel/predictions</code> endpoints.
      * </p>
-     * @return Predictions|null
+     * @return Predictions
      */
-    public function getPredictions(): ?Predictions
+    public function getPredictions(): Predictions
     {
         return $this->predictions;
     }

--- a/src/client/Response.php
+++ b/src/client/Response.php
@@ -170,6 +170,14 @@ class Response
     }
 
     /**
+     * @return object|null
+     */
+    public function getMeta(): ?object
+    {
+        return $this->getBodyAsJsonObject()->{'meta'};
+    }
+
+    /**
      * @return string
      */
     public function __toString(): string

--- a/src/shopping/Availability.php
+++ b/src/shopping/Availability.php
@@ -30,7 +30,7 @@ class Availability
      *   <code>/v1/shopping/availability/flight-availabilities</code> endpoints.
      * </p>
      */
-    private ?FlightAvailabilities $flightAvailabilities;
+    private FlightAvailabilities $flightAvailabilities;
 
     /**
      * Constructor
@@ -46,7 +46,7 @@ class Availability
      *   Get a namespaced client for the
      *   <code>/v1/shopping/availability/flight-availabilities</code> endpoints.
      * </p>
-     * @return FlightAvailabilities|null
+     * @return FlightAvailabilities
      */
     public function getFlightAvailabilities(): ?FlightAvailabilities
     {


### PR DESCRIPTION
There are some must existing endpoint variables that will never be null, 
e.g.
```PHP
private ?DirectDestinations $directDestinations;

/**
* @return DirectDestinations|null
*/
public function getDirectDestinations(): ?DirectDestinations
{
  return $this->directDestinations;
}
```
thus those redundant null type assignments on them should be removed.  
