### PR TITLE
Fix code smells - part one

### DIFF
--- a/src/client/Response.php
+++ b/src/client/Response.php
@@ -192,19 +192,16 @@ class Response
      */
     public function headersToArray(string $str): array
     {
-        $headers = array();
-        $headersTmpArray = explode("\r\n", $str);
+        $headersArray = array();
+        $headersTmpArray = explode("\r\n", $str);  // we don't care about the two \r\n lines at the end of the headers
         for ($i = 0 ; $i < count($headersTmpArray) ; ++$i) {
-            // we don't care about the two \r\n lines at the end of the headers
-            if (strlen($headersTmpArray[$i]) > 0) {
-                // the headers start with HTTP status codes, which do not contain a colon, so we can filter them out too
-                if (strpos($headersTmpArray[$i], ":")) {
-                    $headerName = substr($headersTmpArray[$i], 0, strpos($headersTmpArray[$i], ":"));
-                    $headerValue = substr($headersTmpArray[$i], strpos($headersTmpArray[$i], ":") + 2);
-                    $headers[$headerName] = $headerValue;
-                }
+            // the headers start with HTTP status codes, which do not contain a colon, so we can filter them out too
+            if ((strlen($headersTmpArray[$i]) > 0) && (strpos($headersTmpArray[$i], ":"))) {
+                $headerName = substr($headersTmpArray[$i], 0, strpos($headersTmpArray[$i], ":"));
+                $headerValue = substr($headersTmpArray[$i], strpos($headersTmpArray[$i], ":") + 2);
+                $headersArray[$headerName] = $headerValue;
             }
         }
-        return $headers;
+        return $headersArray;
     }
 }

--- a/src/exceptions/AuthenticationException.php
+++ b/src/exceptions/AuthenticationException.php
@@ -4,15 +4,12 @@ declare(strict_types=1);
 
 namespace Amadeus\Exceptions;
 
-use Amadeus\Client\Response;
-
+/**
+ * Inherit __construct() from parent class
+ *
+ * HTTP status Code : 401
+ * @see BasicHTTPClient::detectError()
+ */
 class AuthenticationException extends ResponseException
 {
-    /**
-     * @param Response|null $response
-     */
-    public function __construct(?Response $response)
-    {
-        parent::__construct($response);
-    }
 }

--- a/src/exceptions/ClientException.php
+++ b/src/exceptions/ClientException.php
@@ -4,15 +4,12 @@ declare(strict_types=1);
 
 namespace Amadeus\Exceptions;
 
-use Amadeus\Client\Response;
-
+/**
+ * Inherit __construct() from parent class
+ *
+ * HTTP status Code : 400
+ * @see BasicHTTPClient::detectError()
+ */
 class ClientException extends ResponseException
 {
-    /**
-     * @param Response|null $response
-     */
-    public function __construct(?Response $response)
-    {
-        parent::__construct($response);
-    }
 }

--- a/src/exceptions/NetworkException.php
+++ b/src/exceptions/NetworkException.php
@@ -4,15 +4,12 @@ declare(strict_types=1);
 
 namespace Amadeus\Exceptions;
 
-use Amadeus\Client\Response;
-
+/**
+ * Inherit __construct() from parent class
+ *
+ * HTTP status Code : 0
+ * @see BasicHTTPClient::detectError()
+ */
 class NetworkException extends ResponseException
 {
-    /**
-     * @param Response|null $response
-     */
-    public function __construct(?Response $response)
-    {
-        parent::__construct($response);
-    }
 }

--- a/src/exceptions/NotFoundException.php
+++ b/src/exceptions/NotFoundException.php
@@ -6,13 +6,12 @@ namespace Amadeus\Exceptions;
 
 use Amadeus\Client\Response;
 
+/**
+ * Inherit __construct() from parent class
+ *
+ * HTTP status Code : 404
+ * @see BasicHTTPClient::detectError()
+ */
 class NotFoundException extends ResponseException
 {
-    /**
-     * @param Response|null $response
-     */
-    public function __construct(?Response $response)
-    {
-        parent::__construct($response);
-    }
 }

--- a/src/exceptions/ServerException.php
+++ b/src/exceptions/ServerException.php
@@ -4,15 +4,13 @@ declare(strict_types=1);
 
 namespace Amadeus\Exceptions;
 
-use Amadeus\Client\Response;
 
+/**
+ * Inherit __construct() from parent class
+ *
+ * HTTP status Code : >= 500
+ * @see BasicHTTPClient::detectError()
+ */
 class ServerException extends ResponseException
 {
-    /**
-     * @param Response|null $response
-     */
-    public function __construct(?Response $response)
-    {
-        parent::__construct($response);
-    }
 }

--- a/src/exceptions/ServerException.php
+++ b/src/exceptions/ServerException.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Amadeus\Exceptions;
 
-
 /**
  * Inherit __construct() from parent class
  *


### PR DESCRIPTION
Fixes #81 

**```/src/client/Response.php```**

- [x] Rename ```$headers``` (which has the same name as the field declared at line 41) to ```$headersArray```.
https://github.com/amadeus4dev/amadeus-php/blob/e3ec95bb3a356a110a5233a9670632bf05e187fb/src/client/Response.php#L41
https://github.com/amadeus4dev/amadeus-php/blob/e3ec95bb3a356a110a5233a9670632bf05e187fb/src/client/Response.php#L195

- [x] Merge this if statement with the enclosing one.
https://github.com/amadeus4dev/amadeus-php/blob/e3ec95bb3a356a110a5233a9670632bf05e187fb/src/client/Response.php#L199-L201


**```/src/exceptions/```**

- [x] Remove this method ```__construct``` to simply inherit it.
e.g. ```/src/exceptions/AuthenticationException.php```
https://github.com/amadeus4dev/amadeus-php/blob/32d6cffa5009ef8e3665e9703cca6e52554d8a68/src/exceptions/AuthenticationException.php#L9-L18



**_The Soanr result after merging this PR: (Code smells counts: from 65 -> 58)_** 
![image](https://user-images.githubusercontent.com/74473717/182373355-412c393e-5dea-4b65-bfe3-9da45deee3fb.png)
 