### PR TITLE
Fix code smells - part two

### DIFF
--- a/tests/booking/HotelBookingsTest.php
+++ b/tests/booking/HotelBookingsTest.php
@@ -58,18 +58,17 @@ final class HotelBookingsTest extends TestCase
             ->willReturn($data);
 
         // Given
-        $body = PHPUnitUtil::readFile(
+        $requestBody4HotelBookings = PHPUnitUtil::readFile(
             PHPUnitUtil::RESOURCE_PATH_ROOT . "hotel_bookings_post_request_ok.json"
         );
         /* @phpstan-ignore-next-line */
         $this->client->expects($this->any())
             ->method("postWithStringBody")
-            ->with("/v1/booking/hotel-bookings", $body)
+            ->with("/v1/booking/hotel-bookings", $requestBody4HotelBookings)
             ->willReturn($response);
 
-
         // When
-        $hotelBookings = (new HotelBookings($this->amadeus))->post($body);
+        $hotelBookings = (new HotelBookings($this->amadeus))->post($requestBody4HotelBookings);
 
         // Then
         $this->assertNotNull($hotelBookings);

--- a/tests/client/RequestTest.php
+++ b/tests/client/RequestTest.php
@@ -102,11 +102,10 @@ final class RequestTest extends TestCase
 
     public function testBuildUriForGetRequest(): void
     {
-        $params = array("foo" => "bar");
         $request = new Request(
             "GET",
             $this->path,
-            $params,
+            $this->params,
             null,
             "token",
             $this->client

--- a/tests/client/RequestTest.php
+++ b/tests/client/RequestTest.php
@@ -21,6 +21,8 @@ use PHPUnit\Framework\TestCase;
 final class RequestTest extends TestCase
 {
     private HTTPClient $client;
+    private string $path;
+    private array $params;
 
     /**
      * @Before
@@ -28,15 +30,16 @@ final class RequestTest extends TestCase
     public function setUp(): void
     {
         $this->client = new BasicHTTPClient(new Configuration("id", "secret"));
+        $this->path = "/foo/bar";
+        $this->params = array("foo" => "bar");
     }
 
     public function testInitializer(): void
     {
-        $params = array("foo" => "bar");
         $request = new Request(
             "GET",
-            "/foo/bar",
-            $params,
+            $this->path,
+            $this->params,
             null,
             "token",
             $this->client
@@ -44,8 +47,8 @@ final class RequestTest extends TestCase
 
         $this->assertEquals("GET", $request->getVerb());
         $this->assertEquals("test.api.amadeus.com", $request->getHost());
-        $this->assertEquals("/foo/bar", $request->getPath());
-        $this->assertEquals($params, $request->getParams());
+        $this->assertEquals($this->path, $request->getPath());
+        $this->assertEquals($this->params, $request->getParams());
         $this->assertNull($request->getBody());
         $this->assertEquals("token", $request->getBearerToken());
         $this->assertEquals(Amadeus::VERSION, $request->getClientVersion());
@@ -70,11 +73,10 @@ final class RequestTest extends TestCase
 
     public function testInitializerWithoutBearerToken(): void
     {
-        $params = array("foo" => "bar");
         $request = new Request(
             "GET",
-            "/foo/bar",
-            $params,
+            $this->path,
+            $this->params,
             null,
             null,
             $this->client
@@ -85,14 +87,14 @@ final class RequestTest extends TestCase
 
     public function testInitializerWithHTTP(): void
     {
-        $client = new BasicHTTPClient((new Configuration("id", "secret"))->setSsl(false));
+        $clientDisableSSL = new BasicHTTPClient((new Configuration("id", "secret"))->setSsl(false));
         $request = new Request(
             "GET",
-            "/foo/bar",
+            $this->path,
             null,
             null,
             null,
-            $client
+            $clientDisableSSL
         );
 
         $this->assertEquals("http", $request->getScheme());
@@ -103,7 +105,7 @@ final class RequestTest extends TestCase
         $params = array("foo" => "bar");
         $request = new Request(
             "GET",
-            "/foo/bar",
+            $this->path,
             $params,
             null,
             "token",
@@ -117,7 +119,7 @@ final class RequestTest extends TestCase
     {
         $request = new Request(
             "GET",
-            "/foo/bar",
+            $this->path,
             null,
             null,
             null,
@@ -129,11 +131,10 @@ final class RequestTest extends TestCase
 
     public function testBuildUriForPostRequest(): void
     {
-        $params = array("foo" => "bar");
         $request = new Request(
-            "GET",
-            "/foo/bar",
-            $params,
+            "POST",
+            $this->path,
+            $this->params,
             null,
             "token",
             $this->client
@@ -146,7 +147,7 @@ final class RequestTest extends TestCase
     {
         $request = new Request(
             "GET",
-            "/foo/bar",
+            $this->path,
             null,
             null,
             "token",
@@ -175,11 +176,10 @@ final class RequestTest extends TestCase
     public function testBuildRequestWithSslCert(): void
     {
         $this->client->setSslCertificate("./cert.pem");
-        $params = array("foo" => "bar");
         $request = new Request(
             "GET",
-            "/foo/bar",
-            $params,
+            $this->path,
+            $this->params,
             null,
             null,
             $this->client

--- a/tests/client/ResponseTest.php
+++ b/tests/client/ResponseTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Amadeus\Tests;
+namespace Amadeus\Tests\Client;
 
 use Amadeus\Client\Request;
 use Amadeus\Client\Response;
@@ -15,6 +15,9 @@ final class ResponseTest extends TestCase
 {
     private Request $request;
     private Response $response;
+    private string $responseHeaders;
+    private string $responseBody;
+    private string $responseResult;
 
     /**
      * @Before
@@ -26,17 +29,16 @@ final class ResponseTest extends TestCase
             "http_code" => 200,
             "header_size" => 8
         );
-        $result =
-            "foo: bar"
-            ." "
+        $this->responseHeaders = "foo: bar";
+        $this->responseBody = " "
             ."{"
             ."\"data\" : [ {"
             ." \"foo\" : \"bar\""
             ." } ]"
-            ."}"
-        ;
+            ."}";
+        $this->responseResult = $this->responseHeaders . $this->responseBody;
         $this->request = $this->createMock(Request::class);
-        $this->response = new Response($this->request, $info, $result);
+        $this->response = new Response($this->request, $info, $this->responseResult);
     }
 
     public function testInitialize(): void
@@ -53,16 +55,11 @@ final class ResponseTest extends TestCase
 
         $this->assertNotNull($this->response->getResult());
         $this->assertEquals(
-            "foo: bar",
+            $this->responseHeaders,
             $this->response->getHeaders()
         );
         $this->assertEquals(
-            " "
-            ."{"
-            ."\"data\" : [ {"
-            ." \"foo\" : \"bar\""
-            ." } ]"
-            ."}",
+            $this->responseBody,
             $this->response->getBody()
         );
     }
@@ -81,14 +78,6 @@ final class ResponseTest extends TestCase
 
     public function testToString(): void
     {
-        $result =
-            "foo: bar"
-            ." "
-            ."{"
-            ."\"data\" : [ {"
-            ." \"foo\" : \"bar\""
-            ." } ]"
-            ."}";
-        $this->assertEquals($result, $this->response->__toString());
+        $this->assertEquals($this->responseResult, $this->response->__toString());
     }
 }

--- a/tests/dutyOfCare/diseases/Covid19AreaReportTest.php
+++ b/tests/dutyOfCare/diseases/Covid19AreaReportTest.php
@@ -18,6 +18,7 @@ use Amadeus\Resources\Border;
 use Amadeus\Resources\DatedQuarantineRestriction;
 use Amadeus\Resources\DatedTracingApplicationRestriction;
 use Amadeus\Resources\DeclarationDocuments;
+use Amadeus\Resources\DiseaseAreaReport;
 use Amadeus\Resources\DiseaseCase;
 use Amadeus\Resources\DiseaseDataSources;
 use Amadeus\Resources\DiseaseInfection;
@@ -80,7 +81,7 @@ final class Covid19AreaReportTest extends TestCase
     /**
      * @throws ResponseException
      */
-    public function test_given_client_when_call_covid_19_area_report_then_ok(): void
+    public function test_given_client_when_call_covid_19_area_report_then_ok(): array
     {
         // Prepare Response
         $fileContent = PHPUnitUtil::readFile(
@@ -105,6 +106,18 @@ final class Covid19AreaReportTest extends TestCase
 
         // Then
         $this->assertNotNull($covid19AreaReport);
+
+        return ["data"=>$data, "covid19AreaReport"=>$covid19AreaReport];
+    }
+
+    /**
+     * @param array $fixtures
+     * @depends test_given_client_when_call_covid_19_area_report_then_ok
+     */
+    public function test_returned_resource_given_client_when_call_covid_19_area_report_then_ok(array $fixtures): void
+    {
+        $data = $fixtures['data'];
+        $covid19AreaReport = $fixtures['covid19AreaReport'];
 
         // Resources
         // DiseaseAreaReport

--- a/tests/dutyOfCare/diseases/Covid19AreaReportTest.php
+++ b/tests/dutyOfCare/diseases/Covid19AreaReportTest.php
@@ -106,6 +106,7 @@ final class Covid19AreaReportTest extends TestCase
 
         // Then
         $this->assertNotNull($covid19AreaReport);
+        $this->assertTrue($covid19AreaReport instanceof DiseaseAreaReport);
 
         return ["data"=>$data, "covid19AreaReport"=>$covid19AreaReport];
     }
@@ -160,6 +161,77 @@ final class Covid19AreaReportTest extends TestCase
         $this->assertEquals("2022-05-19", $areaRestrictions[0]->getDate());
         $this->assertNotNull($areaRestrictions[0]->getText());
         $this->assertEquals("Domestic Travel", $areaRestrictions[0]->getRestrictionType());
+
+        // AreaPolicy
+        $areaPolicy = $covid19AreaReport->getAreaPolicy();
+        $this->assertTrue($areaPolicy instanceof AreaPolicy);
+        $this->assertEquals("2022-05-19", $areaPolicy->getDate());
+        $this->assertNotNull($areaPolicy->getText());
+        $this->assertEquals("Distancing", $areaPolicy->getStatus());
+        $this->assertEquals("2020-03-16", $areaPolicy->getStartDate());
+        $this->assertEquals("indef", $areaPolicy->getEndDate());
+        $this->assertNotNull($areaPolicy->getReferenceLink());
+
+        // Link
+        $relatedArea = $covid19AreaReport->getRelatedArea();
+        $this->assertTrue($relatedArea[0] instanceof Link);
+        $this->assertIsArray($relatedArea[0]->getMethods());
+        $this->assertEquals("Parent", $relatedArea[0]->getRel());
+
+        // AreaVaccinated
+        $areaVaccinated = $covid19AreaReport->getAreaVaccinated();
+        $this->assertTrue($areaVaccinated[0] instanceof AreaVaccinated);
+        $this->assertEquals("2022-05-20", $areaVaccinated[0]->getDate());
+        $this->assertEquals("oneDose", $areaVaccinated[0]->getVaccinationDoseStatus());
+        $this->assertEquals(78.876, $areaVaccinated[0]->getPercentage());
+
+        // __toString()
+        $this->assertEquals(
+            PHPUnitUtil::toString($data),
+            $covid19AreaReport->__toString()
+        );
+        $this->assertEquals(
+            PHPUnitUtil::toString($data->{'area'}),
+            $area->__toString()
+        );
+        $this->assertEquals(
+            PHPUnitUtil::toString($data->{'diseaseInfection'}),
+            $diseaseInfection->__toString()
+        );
+        $this->assertEquals(
+            PHPUnitUtil::toString($data->{'diseaseCases'}),
+            $diseaseCases->__toString()
+        );
+        $this->assertEquals(
+            PHPUnitUtil::toString($data->{'dataSources'}),
+            $dataSources->__toString()
+        );
+        $this->assertEquals(
+            PHPUnitUtil::toString($data->{'areaRestrictions'}[0]),
+            $areaRestrictions[0]->__toString()
+        );
+        $this->assertEquals(
+            PHPUnitUtil::toString($data->{'areaPolicy'}),
+            $areaPolicy->__toString()
+        );
+        $this->assertEquals(
+            PHPUnitUtil::toString($data->{'relatedArea'}[0]),
+            $relatedArea[0]->__toString()
+        );
+        $this->assertEquals(
+            PHPUnitUtil::toString($data->{'areaVaccinated'}[0]),
+            $areaVaccinated[0]->__toString()
+        );
+    }
+
+    /**
+     * @param array $fixtures
+     * @depends test_given_client_when_call_covid_19_area_report_then_ok
+     */
+    public function test_returned_resource2_given_client_when_call_covid_19_area_report_then_ok(array $fixtures): void
+    {
+        $data = $fixtures['data'];
+        $covid19AreaReport = $fixtures['covid19AreaReport'];
 
         // AreaAccessRestriction
         $areaAccessRestriction = $covid19AreaReport->getAreaAccessRestriction();
@@ -254,54 +326,7 @@ final class Covid19AreaReportTest extends TestCase
         $this->assertEquals("Yes", $diseaseVaccination->getPolicy());
         $this->assertEquals("Entry Ban, Quarantine", $diseaseVaccination->getExemptions());
 
-        // AreaPolicy
-        $areaPolicy = $covid19AreaReport->getAreaPolicy();
-        $this->assertTrue($areaPolicy instanceof AreaPolicy);
-        $this->assertEquals("2022-05-19", $areaPolicy->getDate());
-        $this->assertNotNull($areaPolicy->getText());
-        $this->assertEquals("Distancing", $areaPolicy->getStatus());
-        $this->assertEquals("2020-03-16", $areaPolicy->getStartDate());
-        $this->assertEquals("indef", $areaPolicy->getEndDate());
-        $this->assertNotNull($areaPolicy->getReferenceLink());
-
-        // Link
-        $relatedArea = $covid19AreaReport->getRelatedArea();
-        $this->assertTrue($relatedArea[0] instanceof Link);
-        $this->assertIsArray($relatedArea[0]->getMethods());
-        $this->assertEquals("Parent", $relatedArea[0]->getRel());
-
-        // AreaVaccinated
-        $areaVaccinated = $covid19AreaReport->getAreaVaccinated();
-        $this->assertTrue($areaVaccinated[0] instanceof AreaVaccinated);
-        $this->assertEquals("2022-05-20", $areaVaccinated[0]->getDate());
-        $this->assertEquals("oneDose", $areaVaccinated[0]->getVaccinationDoseStatus());
-        $this->assertEquals(78.876, $areaVaccinated[0]->getPercentage());
-
         // __toString()
-        $this->assertEquals(
-            PHPUnitUtil::toString($data),
-            $covid19AreaReport->__toString()
-        );
-        $this->assertEquals(
-            PHPUnitUtil::toString($data->{'area'}),
-            $area->__toString()
-        );
-        $this->assertEquals(
-            PHPUnitUtil::toString($data->{'diseaseInfection'}),
-            $diseaseInfection->__toString()
-        );
-        $this->assertEquals(
-            PHPUnitUtil::toString($data->{'diseaseCases'}),
-            $diseaseCases->__toString()
-        );
-        $this->assertEquals(
-            PHPUnitUtil::toString($data->{'dataSources'}),
-            $dataSources->__toString()
-        );
-        $this->assertEquals(
-            PHPUnitUtil::toString($data->{'areaRestrictions'}[0]),
-            $areaRestrictions[0]->__toString()
-        );
         $this->assertEquals(
             PHPUnitUtil::toString($data->{'areaAccessRestriction'}),
             $areaAccessRestriction->__toString()
@@ -341,18 +366,6 @@ final class Covid19AreaReportTest extends TestCase
         $this->assertEquals(
             PHPUnitUtil::toString($data->{'areaAccessRestriction'}->{'diseaseVaccination'}),
             $diseaseVaccination->__toString()
-        );
-        $this->assertEquals(
-            PHPUnitUtil::toString($data->{'areaPolicy'}),
-            $areaPolicy->__toString()
-        );
-        $this->assertEquals(
-            PHPUnitUtil::toString($data->{'relatedArea'}[0]),
-            $relatedArea[0]->__toString()
-        );
-        $this->assertEquals(
-            PHPUnitUtil::toString($data->{'areaVaccinated'}[0]),
-            $areaVaccinated[0]->__toString()
         );
     }
 }

--- a/tests/exceptions/ExceptionsTest.php
+++ b/tests/exceptions/ExceptionsTest.php
@@ -24,15 +24,20 @@ use PHPUnit\Framework\TestCase;
  */
 final class ExceptionsTest extends TestCase
 {
+    private string $dateFormat = "F j, Y, g:i a";
+    private string $exception = "Amadeus\Exceptions\ResponseException: ";
+    private string $message = "Message: ";
+    private string $url = "Url: ";
+
     public function testNoResponse(): void
     {
         $error = new ResponseException(null);
         $error = explode("\n", $error->__toString());
         $this->assertEquals(
-            '['.date("F j, Y, g:i a").']'."\n"
-            ."Amadeus\Exceptions\ResponseException: [0]"."\n"
-            ."Message: "."\n"
-            ."Url: "."\n",
+            '['.date($this->dateFormat).']'."\n"
+            .$this->exception."[0]"."\n"
+            .$this->message."\n"
+            .$this->url."\n",
             join("\n", array_slice($error, 0, 4))."\n"
         );
     }
@@ -48,10 +53,10 @@ final class ExceptionsTest extends TestCase
         $error = new ResponseException($response);
         $error = explode("\n", $error->__toString());
         $this->assertEquals(
-            '['.date("F j, Y, g:i a").']'."\n"
-            ."Amadeus\Exceptions\ResponseException: [0]"."\n"
-            ."Message: message"."\n"
-            ."Url: "."\n",
+            '['.date($this->dateFormat).']'."\n"
+            .$this->exception."[0]"."\n"
+            .$this->message."message"."\n"
+            .$this->url."\n",
             join("\n", array_slice($error, 0, 4))."\n"
         );
     }
@@ -69,10 +74,10 @@ final class ExceptionsTest extends TestCase
         $error = new ResponseException($response);
         $error = explode("\n", $error->__toString());
         $this->assertEquals(
-            '['.date("F j, Y, g:i a").']'."\n"
-            ."Amadeus\Exceptions\ResponseException: [400]"."\n"
-            ."Message: "."\n"
-            ."Url: "."\n",
+            '['.date($this->dateFormat).']'."\n"
+            .$this->exception."[400]"."\n"
+            .$this->message."\n"
+            .$this->url."\n",
             join("\n", array_slice($error, 0, 4))."\n"
         );
     }
@@ -82,7 +87,7 @@ final class ExceptionsTest extends TestCase
         $request = null;
         $info = array(
             "url" => null,
-            "http_code" => 200,
+            "http_code" => 400,
             "header_size" => 0
         );
         $result = "message";
@@ -90,10 +95,10 @@ final class ExceptionsTest extends TestCase
         $error = new ResponseException($response);
         $error = explode("\n", $error->__toString());
         $this->assertEquals(
-            '['.date("F j, Y, g:i a").']'."\n"
-            ."Amadeus\Exceptions\ResponseException: [200]"."\n"
-            ."Message: message"."\n"
-            ."Url: "."\n",
+            '['.date($this->dateFormat).']'."\n"
+            .$this->exception."[400]"."\n"
+            .$this->message."message"."\n"
+            .$this->url."\n",
             join("\n", array_slice($error, 0, 4))."\n"
         );
     }

--- a/tests/shopping/HotelOfferTest.php
+++ b/tests/shopping/HotelOfferTest.php
@@ -237,57 +237,6 @@ final class HotelOfferTest extends TestCase
         $this->assertEquals("string", $changes[0]->getBase());
         $this->assertNotNull($changes[0]->getMarkups());
 
-        // HotelProductPolicyDetails
-        $policies = $hotelOffer->getPolicies();
-        $this->assertTrue($policies instanceof  HotelProductPolicyDetails);
-        $this->assertEquals("GUARANTEE", $policies->getPaymentType());
-
-        // HotelProductGuaranteePolicy
-        $guarantee = $policies->getGuarantee();
-        $this->assertTrue($guarantee instanceof HotelProductGuaranteePolicy);
-        $this->assertNotNull($guarantee->getDescription());
-
-        // HotelProductPaymentPolicy
-        $acceptedPayments = $guarantee->getAcceptedPayments();
-        $this->assertTrue($acceptedPayments instanceof HotelProductPaymentPolicy);
-        $this->assertEquals(["string"], $acceptedPayments->getCreditCards());
-        $this->assertEquals(["CREDIT_CARD"], $acceptedPayments->getMethods());
-
-        // HotelProductDepositPolicy
-        $deposit = $policies->getDeposit();
-        $this->assertTrue($deposit instanceof HotelProductDepositPolicy);
-        $this->assertEquals("string", $deposit->getAmount());
-        $this->assertEquals("2022-06-20T12:10:33.006Z", $deposit->getDeadline());
-        $this->assertNotNull($deposit->getDescription());
-        $this->assertNotNull($deposit->getAcceptedPayments());
-
-        $prepay = $policies->getPrepay();
-        $this->assertNotNull($prepay);
-        $this->assertTrue($prepay instanceof HotelProductDepositPolicy);
-
-        // HotelProductHoldPolicy
-        $holdTime = $policies->getHoldTime();
-        $this->assertTrue($holdTime instanceof HotelProductHoldPolicy);
-        $this->assertEquals("2022-06-20T12:10:33.006Z", $holdTime->getDeadline());
-
-        // HotelProductCancellationPolicy
-        $cancellation = $policies->getCancellation();
-        $this->assertTrue($cancellation instanceof HotelProductCancellationPolicy);
-        $this->assertEquals("FULL_STAY", $cancellation->getType());
-        $this->assertEquals("string", $cancellation->getAmount());
-        $this->assertEquals(0, $cancellation->getNumberOfNights());
-        $this->assertEquals("string", $cancellation->getPercentage());
-        $this->assertEquals("2022-06-20T12:10:33.006Z", $cancellation->getDeadline());
-        $this->assertNotNull($cancellation->getDescription());
-
-        // HotelProductCheckInOutPolicy
-        $checkInOut = $policies->getCheckInOut();
-        $this->assertTrue($checkInOut instanceof HotelProductCheckInOutPolicy);
-        $this->assertEquals("13:00:00", $checkInOut->getCheckIn());
-        $this->assertNotNull($checkInOut->getCheckInDescription());
-        $this->assertEquals("11:00:00", $checkInOut->getCheckOut());
-        $this->assertNotNull($checkInOut->getCheckOutDescription());
-
         // __toString()
         $this->assertEquals(
             PHPUnitUtil::toString($data),
@@ -349,6 +298,70 @@ final class HotelOfferTest extends TestCase
             PHPUnitUtil::toString($data->{'offers'}[0]->{'price'}->{'variations'}->{'changes'}[0]),
             $changes[0]->__toString()
         );
+    }
+
+    /**
+     * @param array $fixtures
+     * @depends test_given_client_when_call_hotel_offer_then_ok
+     */
+    public function test_returned_resource2_given_client_when_call_hotel_offer_then_ok(array $fixtures): void
+    {
+        $data = $fixtures['data'];
+        $hotelOffers = $fixtures['hotelOffers'];
+        $hotelOffer = $hotelOffers->getOffers()[0];
+
+        // HotelProductPolicyDetails
+        $policies = $hotelOffer->getPolicies();
+        $this->assertTrue($policies instanceof  HotelProductPolicyDetails);
+        $this->assertEquals("GUARANTEE", $policies->getPaymentType());
+
+        // HotelProductGuaranteePolicy
+        $guarantee = $policies->getGuarantee();
+        $this->assertTrue($guarantee instanceof HotelProductGuaranteePolicy);
+        $this->assertNotNull($guarantee->getDescription());
+
+        // HotelProductPaymentPolicy
+        $acceptedPayments = $guarantee->getAcceptedPayments();
+        $this->assertTrue($acceptedPayments instanceof HotelProductPaymentPolicy);
+        $this->assertEquals(["string"], $acceptedPayments->getCreditCards());
+        $this->assertEquals(["CREDIT_CARD"], $acceptedPayments->getMethods());
+
+        // HotelProductDepositPolicy
+        $deposit = $policies->getDeposit();
+        $this->assertTrue($deposit instanceof HotelProductDepositPolicy);
+        $this->assertEquals("string", $deposit->getAmount());
+        $this->assertEquals("2022-06-20T12:10:33.006Z", $deposit->getDeadline());
+        $this->assertNotNull($deposit->getDescription());
+        $this->assertNotNull($deposit->getAcceptedPayments());
+
+        $prepay = $policies->getPrepay();
+        $this->assertNotNull($prepay);
+        $this->assertTrue($prepay instanceof HotelProductDepositPolicy);
+
+        // HotelProductHoldPolicy
+        $holdTime = $policies->getHoldTime();
+        $this->assertTrue($holdTime instanceof HotelProductHoldPolicy);
+        $this->assertEquals("2022-06-20T12:10:33.006Z", $holdTime->getDeadline());
+
+        // HotelProductCancellationPolicy
+        $cancellation = $policies->getCancellation();
+        $this->assertTrue($cancellation instanceof HotelProductCancellationPolicy);
+        $this->assertEquals("FULL_STAY", $cancellation->getType());
+        $this->assertEquals("string", $cancellation->getAmount());
+        $this->assertEquals(0, $cancellation->getNumberOfNights());
+        $this->assertEquals("string", $cancellation->getPercentage());
+        $this->assertEquals("2022-06-20T12:10:33.006Z", $cancellation->getDeadline());
+        $this->assertNotNull($cancellation->getDescription());
+
+        // HotelProductCheckInOutPolicy
+        $checkInOut = $policies->getCheckInOut();
+        $this->assertTrue($checkInOut instanceof HotelProductCheckInOutPolicy);
+        $this->assertEquals("13:00:00", $checkInOut->getCheckIn());
+        $this->assertNotNull($checkInOut->getCheckInDescription());
+        $this->assertEquals("11:00:00", $checkInOut->getCheckOut());
+        $this->assertNotNull($checkInOut->getCheckOutDescription());
+
+        // __toString()
         $this->assertEquals(
             PHPUnitUtil::toString($data->{'offers'}[0]->{'policies'}),
             $policies->__toString()

--- a/tests/shopping/HotelOfferTest.php
+++ b/tests/shopping/HotelOfferTest.php
@@ -84,7 +84,7 @@ final class HotelOfferTest extends TestCase
     /**
      * @throws ResponseException
      */
-    public function test_given_client_when_call_hotel_offer_then_ok(): void
+    public function test_given_client_when_call_hotel_offer_then_ok(): array
     {
         // Prepare Response
         $fileContent = PHPUnitUtil::readFile(
@@ -110,6 +110,19 @@ final class HotelOfferTest extends TestCase
         // Then
         $this->assertNotNull($hotelOffers);
 
+        return ["offerId"=>$params, "data"=>$data, "hotelOffers"=>$hotelOffers];
+    }
+
+    /**
+     * @param array $fixtures
+     * @depends test_given_client_when_call_hotel_offer_then_ok
+     */
+    public function test_returned_resource_given_client_when_call_hotel_offer_then_ok(array $fixtures): void
+    {
+        $data = $fixtures['data'];
+        $hotelOffers = $fixtures['hotelOffers'];
+        $offerId = $fixtures['offerId'];
+
         // Resource
         // HotelOffers
         // See HotelOffersTest.php
@@ -125,10 +138,7 @@ final class HotelOfferTest extends TestCase
         $hotelOffer = $hotelOffers->getOffers()[0];
         $this->assertTrue($hotelOffer instanceof \Amadeus\Resources\HotelOffer);
         $this->assertEquals("hotel-offer", $hotelOffer->getType());
-        $this->assertEquals(
-            "63A93695B58821ABB0EC2B33FE9FAB24D72BF34B1BD7D707293763D8D9378FC3",
-            $hotelOffer->getId()
-        );
+        $this->assertEquals($offerId, $hotelOffer->getId());
         $this->assertEquals("2020-12-30", $hotelOffer->getCheckInDate());
         $this->assertEquals("2020-12-31", $hotelOffer->getCheckOutDate());
         $this->assertEquals("1", $hotelOffer->getRoomQuantity());
@@ -136,8 +146,7 @@ final class HotelOfferTest extends TestCase
         $this->assertEquals("FAMILY_PLAN", $hotelOffer->getCategory());
         $this->assertEquals("ROOM_ONLY", $hotelOffer->getBoardType());
         $this->assertEquals(
-            "https://test.travel.api.amadeus.com/v2/shopping/hotel-offers/"
-            ."63A93695B58821ABB0EC2B33FE9FAB24D72BF34B1BD7D707293763D8D9378FC3",
+            "https://test.travel.api.amadeus.com/v2/shopping/hotel-offers/" . $offerId,
             $hotelOffer->getSelf()
         );
 

--- a/tests/shopping/availability/FlightAvailabilitiesTest.php
+++ b/tests/shopping/availability/FlightAvailabilitiesTest.php
@@ -59,7 +59,7 @@ final class FlightAvailabilitiesTest extends TestCase
     /**
      * @throws ResponseException
      */
-    public function test_given_client_when_call_flight_availabilities_then_ok(): void
+    public function test_given_client_when_call_flight_availabilities_then_ok(): array
     {
         // Prepare Response
         $fileContent = PHPUnitUtil::readFile(
@@ -88,6 +88,18 @@ final class FlightAvailabilitiesTest extends TestCase
         // Then
         $this->assertNotNull($flightAvailabilities);
         $this->assertEquals(4, sizeof($flightAvailabilities));
+
+        return ["data"=>$data, "flightAvailabilities"=>$flightAvailabilities];
+    }
+
+    /**
+     * @param array $fixtures
+     * @depends test_given_client_when_call_flight_availabilities_then_ok
+     */
+    public function test_returned_resource_given_client_when_call_flight_availabilities_then_ok(array $fixtures): void
+    {
+        $data = $fixtures['data'];
+        $flightAvailabilities = $fixtures['flightAvailabilities'];
 
         // Resources
         // FlightAvailability

--- a/tests/shopping/availability/FlightAvailabilitiesTest.php
+++ b/tests/shopping/availability/FlightAvailabilitiesTest.php
@@ -72,18 +72,18 @@ final class FlightAvailabilitiesTest extends TestCase
             ->willReturn($data);
 
         // Given
-        $body = PHPUnitUtil::readFile(
+        $requestBody4FlightAvailabilities = PHPUnitUtil::readFile(
             PHPUnitUtil::RESOURCE_PATH_ROOT . "flight_availabilities_post_request_ok.json"
         );
         /* @phpstan-ignore-next-line */
         $this->client->expects($this->any())
             ->method("postWithStringBody")
-            ->with("/v1/shopping/availability/flight-availabilities", $body)
+            ->with("/v1/shopping/availability/flight-availabilities", $requestBody4FlightAvailabilities)
             ->willReturn($response);
 
         // When
         $flightAvailabilitiesSearch = new FlightAvailabilities($this->amadeus);
-        $flightAvailabilities = $flightAvailabilitiesSearch->post($body);
+        $flightAvailabilities = $flightAvailabilitiesSearch->post($requestBody4FlightAvailabilities);
 
         // Then
         $this->assertNotNull($flightAvailabilities);


### PR DESCRIPTION
Fixes #83 (see details on the issue)

- [x] Fix: String literals should not be duplicated
- [x] Fix: Local variables should not have the same name as class fields
- [x] Fix: Track uses of "TODO" tags
- [x] Fix: Source files should not have any duplicated blocks
- [x] Fix: Functions should not have too many lines of code

**_The Sonar result after merging this PR (plus already merged PR #82) :_** 

> Code smells counts: from 58 to 41
> Duplication: from 1.3% to 1.2%

![image](https://user-images.githubusercontent.com/74473717/182574956-7e20e55f-0f17-4d1a-b56e-46705dcfaf9c.png)
